### PR TITLE
fix provider config error when using client certificates that don't exist (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.1 (May 28, 2025)
+
+FEATURES:
+  * **Fix provider config error when using client certificates that don't exist** ([#5](https://github.com/mmianl/terraform-provider-powerdns/issues/5), @mmianl)
+
 ## 1.6.0 (May 23, 2025)
 
 FEATURES:

--- a/powerdns/config.go
+++ b/powerdns/config.go
@@ -41,7 +41,7 @@ func (c *Config) Client() (*Client, error) {
 	if c.ClientCertFile != "" && c.ClientCertKeyFile != "" {
 		cert, err := tls.LoadX509KeyPair(c.ClientCertFile, c.ClientCertKeyFile)
 		if err != nil {
-			log.Fatalf("Unable to load client cert: %v", err)
+			return nil, fmt.Errorf("unable to load client cert: %v", err)
 		}
 
 		tlsConfig.Certificates = []tls.Certificate{cert}


### PR DESCRIPTION
closes #5