### PR TITLE
Enforce canonical DNS naming in PowerDNS provider

### DIFF
--- a/powerdns/resource_powerdns_ptr_record.go
+++ b/powerdns/resource_powerdns_ptr_record.go
@@ -32,11 +32,20 @@ func resourcePDNSPTRRecord() *schema.Resource {
 				Description:  "The IP address to create a PTR record for (IPv4 or IPv6).",
 			},
 			"hostname": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-				Description:  "The hostname to point to.",
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) < 1 || len(value) > 255 {
+						errors = append(errors, fmt.Errorf("%q must be between 1 and 255 characters", k))
+					}
+					if !strings.HasSuffix(value, ".") {
+						errors = append(errors, fmt.Errorf("%q must be a fully qualified domain name ending with a dot", k))
+					}
+					return
+				},
+				Description: "The hostname to point to. Must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., \"ns1.example.com.\").",
 			},
 			"ttl": {
 				Type:         schema.TypeInt,
@@ -46,10 +55,17 @@ func resourcePDNSPTRRecord() *schema.Resource {
 				Description:  "The TTL of the PTR record.",
 			},
 			"reverse_zone": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "The name of the reverse zone (e.g., '16.172.in-addr.arpa.' or '8.b.d.0.1.0.0.2.ip6.arpa.').",
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if !strings.HasSuffix(value, ".") {
+						errors = append(errors, fmt.Errorf("%q must be a fully qualified domain name ending with a dot", k))
+					}
+					return
+				},
+				Description: "The name of the reverse zone. Must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., \"16.172.in-addr.arpa.\" or \"8.b.d.0.1.0.0.2.ip6.arpa.\").",
 			},
 		},
 	}

--- a/powerdns/resource_powerdns_record.go
+++ b/powerdns/resource_powerdns_record.go
@@ -26,11 +26,27 @@ func resourcePDNSRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if !strings.HasSuffix(value, ".") {
+						errors = append(errors, fmt.Errorf("%q must be a fully qualified domain name ending with a dot", k))
+					}
+					return
+				},
+				Description: "The name of the zone. Must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., \"example.com.\").",
 			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if !strings.HasSuffix(value, ".") {
+						errors = append(errors, fmt.Errorf("%q must be a fully qualified domain name ending with a dot", k))
+					}
+					return
+				},
+				Description: "The name of the record. Must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., \"www.example.com.\").",
 			},
 			"type": {
 				Type:     schema.TypeString,

--- a/powerdns/resource_powerdns_recursor_forward_zone.go
+++ b/powerdns/resource_powerdns_recursor_forward_zone.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourcePDNSRecursorForwardZone() *schema.Resource {
@@ -21,11 +20,20 @@ func resourcePDNSRecursorForwardZone() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-				Description:  "The zone name to forward",
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if len(value) < 1 || len(value) > 255 {
+						errors = append(errors, fmt.Errorf("%q must be between 1 and 255 characters", k))
+					}
+					if !strings.HasSuffix(value, ".") {
+						errors = append(errors, fmt.Errorf("%q must be a fully qualified domain name ending with a dot", k))
+					}
+					return
+				},
+				Description: "The zone name to forward. Must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., \"example.com.\").",
 			},
 			"servers": {
 				Type:     schema.TypeList,

--- a/powerdns/resource_powerdns_recursor_forward_zone_test.go
+++ b/powerdns/resource_powerdns_recursor_forward_zone_test.go
@@ -19,7 +19,7 @@ func TestAccPowerDNSRecursorForwardZone_Basic(t *testing.T) {
 				Config: testAccPowerDNSRecursorForwardZoneConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPowerDNSRecursorForwardZoneExists("powerdns_recursor_forward_zone.test"),
-					resource.TestCheckResourceAttr("powerdns_recursor_forward_zone.test", "zone", "example.com"),
+					resource.TestCheckResourceAttr("powerdns_recursor_forward_zone.test", "zone", "example.com."),
 					resource.TestCheckResourceAttr("powerdns_recursor_forward_zone.test", "servers.#", "2"),
 					resource.TestCheckResourceAttr("powerdns_recursor_forward_zone.test", "servers.0", "192.0.2.1"),
 					resource.TestCheckResourceAttr("powerdns_recursor_forward_zone.test", "servers.1", "192.0.2.2"),
@@ -31,7 +31,7 @@ func TestAccPowerDNSRecursorForwardZone_Basic(t *testing.T) {
 
 const testAccPowerDNSRecursorForwardZoneConfig = `
 resource "powerdns_recursor_forward_zone" "test" {
-  zone    = "example.com"
+  zone    = "example.com."
   servers = ["192.0.2.1", "192.0.2.2"]
 }
 `

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -29,6 +29,14 @@ func resourcePDNSZone() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if !strings.HasSuffix(value, ".") {
+						errors = append(errors, fmt.Errorf("%q must be a fully qualified domain name ending with a dot", k))
+					}
+					return
+				},
+				Description: "The name of the zone. Must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., \"example.com.\").",
 			},
 
 			"kind": {
@@ -48,8 +56,17 @@ func resourcePDNSZone() *schema.Resource {
 			},
 
 			"nameservers": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+						value := v.(string)
+						if !strings.HasSuffix(value, ".") {
+							errors = append(errors, fmt.Errorf("%q must be a fully qualified domain name ending with a dot", k))
+						}
+						return
+					},
+				},
 				Optional: true,
 				ForceNew: true,
 			},

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -389,8 +389,8 @@ Different DNS record types require specific formatting for their content. Here a
 
 The following arguments are supported:
 
-- `zone` - (Required) The name of zone to contain this record.
-- `name` - (Required) The name of the record.
+- `zone` - (Required) The name of the zone. Must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., "example.com.").
+- `name` - (Required) The name of the record. Must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., "www.example.com.").
 - `type` - (Required) The record type.
 - `ttl` - (Required) The TTL of the record.
 - `records` - (Required) A string list of records.

--- a/website/docs/r/recursor_forward_zone.html.markdown
+++ b/website/docs/r/recursor_forward_zone.html.markdown
@@ -14,12 +14,12 @@ Provides a PowerDNS recursor forward zone resource for managing DNS forwarding c
 
 ```hcl
 resource "powerdns_recursor_forward_zone" "example" {
-  zone    = "example.com"
+  zone    = "example.com."
   servers = ["192.0.2.1", "192.0.2.2"]
 }
 
 resource "powerdns_recursor_forward_zone" "internal" {
-  zone    = "internal.company.com"
+  zone    = "internal.company.com."
   servers = ["10.0.0.53"]
 }
 ```
@@ -28,7 +28,7 @@ resource "powerdns_recursor_forward_zone" "internal" {
 
 This resource supports the following arguments:
 
-- `zone` - (Required) The DNS zone name to forward queries for.
+- `zone` - (Required) The DNS zone name to forward queries for. Must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., "example.com.").
 - `servers` - (Required) A list of DNS server IP addresses to forward queries to for this zone.
 
 ## Notes
@@ -37,3 +37,4 @@ This resource supports the following arguments:
 - Forward zone configuration is managed through the `forward-zones` recursor setting.
 - Multiple forward zones can be configured independently.
 - Changes take effect immediately in the running recursor.
+- The `zone` should be specified as a fully qualified domain name (FQDN), ending with a trailing dot (e.g., "example.com.").

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -36,10 +36,10 @@ resource "powerdns_zone" "fubar" {
 
 This resource supports the following arguments:
 
-- `name` - (Required) The name of zone.
+- `name` - (Required) The name of the zone. Must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., "example.com.").
 - `kind` - (Required) The kind of the zone.
 - `account` - (Optional) The account owning the zone. (Default to "admin")
-- `nameservers` - (Optional) List of zone nameservers.
+- `nameservers` - (Optional) List of zone nameservers. Each nameserver must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., "ns1.example.com.").
 - `masters` - (Optional) List of IP addresses configured as a master for this zone. This argument must be provided when `kind` is set to `Slave`.
 - `soa_edit_api` - (Optional) This should map to one of the [supported API values](https://doc.powerdns.com/authoritative/dnsupdate.html#soa-edit-dnsupdate-settings) *or* in [case you wish to remove the setting](https://doc.powerdns.com/authoritative/domainmetadata.html#soa-edit-api), set this argument as `""` (that will translate to the API value `""`).
 


### PR DESCRIPTION
**Description:**
This PR adds validation to ensure all DNS zone and record names in the PowerDNS Terraform provider are specified as fully qualified domain names (FQDNs) ending with trailing dots, aligning with standard DNS conventions and PowerDNS API requirements. Below are what changes I did:

- `powerdns_zone`: Added validation for name and nameservers fields to require FQDNs with trailing dots
- `powerdns_record`: Added validation for zone and name fields to require FQDNs with trailing dots
- `powerdns_ptr_record`: Added validation for hostname and reverse_zone fields to require FQDNs with trailing dots
- `powerdns_recursor_forward_zone`: Added validation for zone field to require FQDN with trailing dot
- Updated documentation for all affected resources to clarify the FQDN requirement
- Updated test configurations to use canonical formats