### PR TITLE
feat: add catalog, views, and networks support for PowerDNS 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-provider-powerdns
 
-The Terraform PowerDNS provider allows you to manage PowerDNS zones and records using Terraform. It is maintained by mmianl.
+The Terraform PowerDNS provider allows you to manage PowerDNS zones, records, views, and networks using Terraform. It is maintained by mmianl.
 
 ## Requirements
 
@@ -31,6 +31,17 @@ provider "powerdns" {
 # Note: The provider supports both PowerDNS Authoritative Server and PowerDNS Recursor.
 # Configure server_url for authoritative operations and recursor_server_url for recursor operations.
 ```
+
+### Supported authoritative resources
+
+- `powerdns_zone`
+- `powerdns_zone_metadata`
+- `powerdns_record`
+- `powerdns_record_soa`
+- `powerdns_ptr_record`
+- `powerdns_reverse_zone`
+- `powerdns_view`
+- `powerdns_network`
 
 For detailed usage see [provider's documentation page](https://registry.terraform.io/providers/mmianl/powerdns/latest/docs)
 

--- a/acc-tests/docker-compose.yml
+++ b/acc-tests/docker-compose.yml
@@ -9,14 +9,7 @@ services:
     command: >
       -lc '
         set -eu;
-        if [ ! -s /data/pdns.sqlite3 ]; then
-          sqlite3 /var/lib/powerdns/pdns.sqlite3 '.schema' > /var/lib/powerdns/pdns.sqlite3.sql
-          sqlite3 /data/pdns.sqlite3 < /var/lib/powerdns/pdns.sqlite3.sql;
-          chown -R pdns:pdns /data
-          echo "SQLite schema created at /data/pdns.sqlite3";
-        else
-          echo "SQLite DB already present; skipping init.";
-        fi
+        chown -R pdns:pdns /data
       '
     volumes:
       - "pdns_data:/data"

--- a/acc-tests/pdns.conf
+++ b/acc-tests/pdns.conf
@@ -1,6 +1,7 @@
-# --- Storage (SQLite) ---
-launch=gsqlite3
-gsqlite3-database=/data/pdns.sqlite3
+# --- Storage (LMDB) ---
+launch=lmdb
+lmdb-filename=/data/db.lmdb
+
 
 # --- API / Web server for Terraform tests ---
 api=yes
@@ -18,3 +19,4 @@ local-port=5300
 default-ttl=60
 primary=yes
 version-string=anonymous
+views=yes

--- a/e2e-tests/assert_test.go
+++ b/e2e-tests/assert_test.go
@@ -92,6 +92,7 @@ func terraformOutput(t *testing.T, name string, v interface{}) {
 type authZone struct {
 	Name        string      `json:"name"`
 	Kind        string      `json:"kind"`
+	Catalog     string      `json:"catalog"`
 	Masters     []string    `json:"masters"`
 	Nameservers []string    `json:"nameservers"`
 	RRSets      []authRRSet `json:"rrsets"`
@@ -141,6 +142,22 @@ type soaDataSourceOutput struct {
 type zoneMetadata struct {
 	Kind     string   `json:"kind"`
 	Metadata []string `json:"metadata"`
+}
+
+type authView struct {
+	ID    string   `json:"id"`
+	Name  string   `json:"name"`
+	Zones []string `json:"zones"`
+}
+
+type authNetwork struct {
+	Network string `json:"network"`
+	View    string `json:"view"`
+}
+
+type viewZoneAssociationOutput struct {
+	View string `json:"view"`
+	Zone string `json:"zone"`
 }
 
 // Recursor config setting
@@ -392,6 +409,26 @@ func TestPowerDNSAuthoritativeResources(t *testing.T) {
 				if !strings.Contains(content, "hostmaster.test-disabled-soa.example.com.") {
 					t.Fatalf("disabled SOA record content missing rname: got %q", content)
 				}
+				parts := strings.Fields(content)
+				if len(parts) != 7 {
+					t.Fatalf("disabled SOA content: expected 7 fields, got %d: %q", len(parts), content)
+				}
+				refresh, _ := strconv.Atoi(parts[3])
+				retry, _ := strconv.Atoi(parts[4])
+				expire, _ := strconv.Atoi(parts[5])
+				minimum, _ := strconv.Atoi(parts[6])
+				if refresh != 7200 {
+					t.Fatalf("disabled SOA refresh: got %d, want 7200", refresh)
+				}
+				if retry != 1800 {
+					t.Fatalf("disabled SOA retry: got %d, want 1800", retry)
+				}
+				if expire != 1209600 {
+					t.Fatalf("disabled SOA expire: got %d, want 1209600", expire)
+				}
+				if minimum != 600 {
+					t.Fatalf("disabled SOA minimum: got %d, want 600", minimum)
+				}
 				break
 			}
 		}
@@ -457,7 +494,21 @@ func TestPowerDNSAuthoritativeResources(t *testing.T) {
 		}
 	}
 
-	// 5) Zone metadata: verify resource
+	// 5) Zone variant: test.example.com..internal
+	{
+		req := newRequest(t, http.MethodGet, base, "/api/v1/servers/localhost/zones/test.example.com..internal")
+		var zone authZone
+		doJSON(t, req, &zone)
+
+		if zone.Name != "test.example.com..internal" {
+			t.Fatalf("variant zone name: got %q, want %q", zone.Name, "test.example.com..internal")
+		}
+		if zone.Kind != "Native" {
+			t.Fatalf("variant zone kind: got %q, want %q", zone.Kind, "Native")
+		}
+	}
+
+	// 6) Zone metadata: verify resource
 	{
 		req := newRequest(t, http.MethodGet, base, "/api/v1/servers/localhost/zones/test.example.com./metadata")
 		var metadataList []zoneMetadata
@@ -472,7 +523,78 @@ func TestPowerDNSAuthoritativeResources(t *testing.T) {
 		assertMetadataKindValues(t, metadataByKind, "ALLOW-AXFR-FROM", []string{"AUTO-NS", "2001:db8::/48"})
 	}
 
-	// 6) Reverse zone: 172.16.0.0/24
+	// 7) View and network mapping
+	{
+		req := newRequest(t, http.MethodGet, base, "/api/v1/servers/localhost/views/internal")
+		var view authView
+		doJSON(t, req, &view)
+
+		zoneSet := valuesToSet(view.Zones)
+		for _, want := range []string{"test2.example.com.", "test.example.com..internal"} {
+			if !zoneSet[want] {
+				t.Fatalf("view internal missing zone %q in %v", want, view.Zones)
+			}
+		}
+
+		var test2Association viewZoneAssociationOutput
+		terraformOutput(t, "powerdns_view_zone_association_test2", &test2Association)
+		if test2Association.View != "internal" {
+			t.Fatalf("test2 view association view: got %q, want %q", test2Association.View, "internal")
+		}
+		if test2Association.Zone != "test2.example.com." {
+			t.Fatalf("test2 view association zone: got %q, want %q", test2Association.Zone, "test2.example.com.")
+		}
+
+		var variantAssociation viewZoneAssociationOutput
+		terraformOutput(t, "powerdns_view_zone_association_test_variant", &variantAssociation)
+		if variantAssociation.View != "internal" {
+			t.Fatalf("variant view association view: got %q, want %q", variantAssociation.View, "internal")
+		}
+		if variantAssociation.Zone != "test.example.com..internal" {
+			t.Fatalf("variant view association zone: got %q, want %q", variantAssociation.Zone, "test.example.com..internal")
+		}
+
+		req = newRequest(t, http.MethodGet, base, "/api/v1/servers/localhost/networks/192.0.2.0/24")
+		var network authNetwork
+		doJSON(t, req, &network)
+
+		if network.Network != "192.0.2.0/24" {
+			t.Fatalf("network CIDR: got %q, want %q", network.Network, "192.0.2.0/24")
+		}
+		if network.View != "internal" {
+			t.Fatalf("network view: got %q, want %q", network.View, "internal")
+		}
+	}
+
+	// 8) Catalog producer zone and catalog zone membership
+	{
+		req := newRequest(t, http.MethodGet, base, "/api/v1/servers/localhost/zones/catalog-a.example.")
+		var catalogZone authZone
+		doJSON(t, req, &catalogZone)
+
+		if catalogZone.Name != "catalog-a.example." {
+			t.Fatalf("catalog producer zone name: got %q, want %q", catalogZone.Name, "catalog-a.example.")
+		}
+		if catalogZone.Kind != "Producer" {
+			t.Fatalf("catalog producer zone kind: got %q, want %q", catalogZone.Kind, "Producer")
+		}
+
+		req = newRequest(t, http.MethodGet, base, "/api/v1/servers/localhost/zones/catalog-member.example.com.")
+		var zone authZone
+		doJSON(t, req, &zone)
+
+		if zone.Name != "catalog-member.example.com." {
+			t.Fatalf("catalog member zone name: got %q, want %q", zone.Name, "catalog-member.example.com.")
+		}
+		if zone.Kind != "Master" {
+			t.Fatalf("catalog member zone kind: got %q, want %q", zone.Kind, "Master")
+		}
+		if zone.Catalog != "catalog-a.example." {
+			t.Fatalf("catalog member catalog: got %q, want %q", zone.Catalog, "catalog-a.example.")
+		}
+	}
+
+	// 9) Reverse zone: 172.16.0.0/24
 	{
 		reverseZoneName := ipv4ReverseZoneName(t, "172.16.0.0/24")
 		req := newRequest(t, http.MethodGet, base, "/api/v1/servers/localhost/zones/"+reverseZoneName)

--- a/e2e-tests/docker-compose.yml
+++ b/e2e-tests/docker-compose.yml
@@ -9,18 +9,10 @@ services:
     command: >
       -lc '
         set -eu;
-        if [ ! -s /data/pdns.sqlite3 ]; then
-          sqlite3 /var/lib/powerdns/pdns.sqlite3 '.schema' > /var/lib/powerdns/pdns.sqlite3.sql
-          sqlite3 /data/pdns.sqlite3 < /var/lib/powerdns/pdns.sqlite3.sql;
-          chown -R pdns:pdns /data
-          echo "SQLite schema created at /data/pdns.sqlite3";
-        else
-          echo "SQLite DB already present; skipping init.";
-        fi
+        chown -R pdns:pdns /data;
       '
     volumes:
       - "pdns_data:/data"
-      - "schema:/schema:ro"
     restart: "no"
 
   pdns:

--- a/e2e-tests/pdns.conf
+++ b/e2e-tests/pdns.conf
@@ -1,6 +1,6 @@
-# --- Storage (SQLite) ---
-launch=gsqlite3
-gsqlite3-database=/data/pdns.sqlite3
+# --- Storage (LMDB) ---
+launch=lmdb
+lmdb-filename=/data/db.lmdb
 
 # --- API / Web server for Terraform tests ---
 api=yes
@@ -18,3 +18,4 @@ local-port=5300
 default-ttl=60
 primary=yes
 version-string=anonymous
+views=yes

--- a/e2e-tests/terraform/main.tf
+++ b/e2e-tests/terraform/main.tf
@@ -145,32 +145,65 @@ resource "powerdns_record_soa" "soa" {
   minimum = 3600
 }
 
-resource "powerdns_zone" "test2" {
-  name = "test2.example.com."
-  kind = "Native"
-}
-
 resource "powerdns_zone" "test_disabled_soa" {
   name = "test-disabled-soa.example.com."
   kind = "Native"
 }
 
-resource "powerdns_record_soa" "disabled_soa" {
+resource "powerdns_record_soa" "disabled_zone" {
   zone     = powerdns_zone.test_disabled_soa.name
   name     = powerdns_zone.test_disabled_soa.name
   ttl      = 1800
-  disabled = true
   mname    = "dns1.${powerdns_zone.test_disabled_soa.name}"
   rname    = "hostmaster.${powerdns_zone.test_disabled_soa.name}"
   refresh  = 7200
   retry    = 1800
   expire   = 1209600
   minimum  = 600
+  disabled = true
 }
 
-data "powerdns_record_soa" "disabled_soa" {
+data "powerdns_record_soa" "disabled_zone" {
   zone = powerdns_zone.test_disabled_soa.name
   name = powerdns_zone.test_disabled_soa.name
 
-  depends_on = [powerdns_record_soa.disabled_soa]
+  depends_on = [powerdns_record_soa.disabled_zone]
+}
+
+resource "powerdns_zone" "test2" {
+  name = "test2.example.com."
+  kind = "Native"
+}
+
+resource "powerdns_zone" "test_variant" {
+  name = "test.example.com..internal"
+  kind = "Native"
+}
+
+resource "powerdns_zone" "catalog" {
+  name = "catalog-a.example."
+  kind = "Producer"
+}
+
+resource "powerdns_zone" "catalog_member" {
+  name    = "catalog-member.example.com."
+  kind    = "Master"
+  catalog = "catalog-a.example."
+
+  depends_on = [powerdns_zone.catalog]
+}
+
+resource "powerdns_view_zone_association" "test2" {
+  view = "internal"
+  zone = powerdns_zone.test2.name
+}
+
+resource "powerdns_view_zone_association" "test_variant" {
+  view = "internal"
+  zone = powerdns_zone.test_variant.name
+}
+
+resource "powerdns_network" "internal_clients" {
+  network = "192.0.2.0/24"
+  view    = powerdns_view_zone_association.test2.view
 }

--- a/e2e-tests/terraform/outputs.tf
+++ b/e2e-tests/terraform/outputs.tf
@@ -70,18 +70,42 @@ output "data_powerdns_record_soa" {
   value = data.powerdns_record_soa.soa
 }
 
-output "data_powerdns_record_soa_disabled" {
-  value = data.powerdns_record_soa.soa.disabled
+output "powerdns_zone_test_disabled_soa" {
+  value = powerdns_zone.test_disabled_soa
 }
 
 output "powerdns_record_soa_disabled_zone" {
-  value = powerdns_record_soa.disabled_soa
+  value = powerdns_record_soa.disabled_zone
 }
 
 output "data_powerdns_record_soa_disabled_zone" {
-  value = data.powerdns_record_soa.disabled_soa
+  value = data.powerdns_record_soa.disabled_zone
 }
 
 output "data_powerdns_record_soa_disabled_zone_disabled" {
-  value = data.powerdns_record_soa.disabled_soa.disabled
+  value = data.powerdns_record_soa.disabled_zone.disabled
+}
+
+output "powerdns_zone_test_variant" {
+  value = powerdns_zone.test_variant
+}
+
+output "powerdns_zone_catalog" {
+  value = powerdns_zone.catalog
+}
+
+output "powerdns_zone_catalog_member" {
+  value = powerdns_zone.catalog_member
+}
+
+output "powerdns_view_zone_association_test2" {
+  value = powerdns_view_zone_association.test2
+}
+
+output "powerdns_view_zone_association_test_variant" {
+  value = powerdns_view_zone_association.test_variant
+}
+
+output "powerdns_network_internal_clients" {
+  value = powerdns_network.internal_clients
 }

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -201,6 +201,7 @@ type ZoneInfo struct {
 	Name               string              `json:"name"`
 	URL                string              `json:"url"`
 	Kind               string              `json:"kind"`
+	Catalog            string              `json:"catalog,omitempty"`
 	DNSSec             bool                `json:"dnsssec"`
 	Serial             int64               `json:"serial"`
 	Records            []Record            `json:"records,omitempty"`
@@ -215,9 +216,23 @@ type ZoneInfo struct {
 type ZoneInfoUpd struct {
 	Name       string   `json:"name"`
 	Kind       string   `json:"kind"`
+	Catalog    string   `json:"catalog,omitempty"`
 	SoaEditAPI string   `json:"soa_edit_api,omitempty"`
 	Account    string   `json:"account"`
 	Masters    []string `json:"masters,omitempty"`
+}
+
+// View represents a PowerDNS view object.
+type View struct {
+	ID    string   `json:"id,omitempty"`
+	Name  string   `json:"name,omitempty"`
+	Zones []string `json:"zones,omitempty"`
+}
+
+// Network represents a PowerDNS network object.
+type Network struct {
+	Network string `json:"network"`
+	View    string `json:"view"`
 }
 
 // ZoneMetadata represents a single metadata kind with all configured values.
@@ -634,7 +649,6 @@ func (client *PowerDNSClient) ReplaceZoneMetadata(ctx context.Context, zone stri
 	if err != nil {
 		return err
 	}
-
 	req, err := client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/servers/localhost/zones/%s/metadata/%s", zone, kind), body)
 	if err != nil {
 		return err
@@ -941,6 +955,324 @@ func (client *PowerDNSClient) DeleteRecordSetByID(ctx context.Context, zone stri
 		return err
 	}
 	return client.DeleteRecordSet(ctx, zone, name, tpe)
+}
+
+// ListViews returns all configured views.
+func (client *PowerDNSClient) ListViews(ctx context.Context) ([]string, error) {
+	req, err := client.newRequest(ctx, http.MethodGet, "/servers/localhost/views", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			tflog.Warn(ctx, "Error closing response body", map[string]any{
+				"error":  err.Error(),
+				"method": req.Method,
+				"url":    req.URL.String(),
+			})
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		var errorResp errorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
+			return nil, fmt.Errorf("error listing views: failed to decode error response: %w", err)
+		}
+		return nil, fmt.Errorf("error listing views: %q", errorResp.ErrorMsg)
+	}
+
+	var views []string
+	if err := json.NewDecoder(resp.Body).Decode(&views); err != nil {
+		return nil, err
+	}
+
+	return views, nil
+}
+
+// GetView retrieves a specific view.
+func (client *PowerDNSClient) GetView(ctx context.Context, viewName string) (*View, error) {
+	req, err := client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/servers/localhost/views/%s", viewName), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			tflog.Warn(ctx, "Error closing response body", map[string]any{
+				"error":  err.Error(),
+				"method": req.Method,
+				"url":    req.URL.String(),
+				"view":   viewName,
+			})
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var view View
+		if err := json.NewDecoder(resp.Body).Decode(&view); err != nil {
+			return nil, err
+		}
+		if view.Name == "" {
+			view.Name = viewName
+		}
+		return &view, nil
+	case http.StatusNotFound:
+		return nil, ErrNotFound
+	default:
+		var errorResp errorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
+			return nil, fmt.Errorf("error getting view %s: failed to decode error response: %w", viewName, err)
+		}
+		return nil, fmt.Errorf("error getting view %s: %q", viewName, errorResp.ErrorMsg)
+	}
+}
+
+// AddZoneToView associates a zone with a view.
+func (client *PowerDNSClient) AddZoneToView(ctx context.Context, viewName, zoneName string) error {
+	body, err := json.Marshal(struct {
+		Name string `json:"name"`
+	}{Name: zoneName})
+	if err != nil {
+		return err
+	}
+
+	req, err := client.newRequest(ctx, http.MethodPost, fmt.Sprintf("/servers/localhost/views/%s", viewName), body)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			tflog.Warn(ctx, "Error closing response body", map[string]any{
+				"error":  err.Error(),
+				"method": req.Method,
+				"url":    req.URL.String(),
+				"view":   viewName,
+				"zone":   zoneName,
+			})
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
+		var errorResp errorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
+			return fmt.Errorf("error adding zone %s to view %s: failed to decode error response: %w", zoneName, viewName, err)
+		}
+		return fmt.Errorf("error adding zone %s to view %s: %q", zoneName, viewName, errorResp.ErrorMsg)
+	}
+
+	return nil
+}
+
+// RemoveZoneFromView removes a zone from a view.
+func (client *PowerDNSClient) RemoveZoneFromView(ctx context.Context, viewName, zoneName string) error {
+	req, err := client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/servers/localhost/views/%s/%s", viewName, zoneName), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			tflog.Warn(ctx, "Error closing response body", map[string]any{
+				"error":  err.Error(),
+				"method": req.Method,
+				"url":    req.URL.String(),
+				"view":   viewName,
+				"zone":   zoneName,
+			})
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		return ErrNotFound
+	default:
+		var errorResp errorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
+			return fmt.Errorf("error removing zone %s from view %s: failed to decode error response: %w", zoneName, viewName, err)
+		}
+		return fmt.Errorf("error removing zone %s from view %s: %q", zoneName, viewName, errorResp.ErrorMsg)
+	}
+}
+
+// ListNetworks returns all configured networks.
+func (client *PowerDNSClient) ListNetworks(ctx context.Context) ([]Network, error) {
+	req, err := client.newRequest(ctx, http.MethodGet, "/servers/localhost/networks", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			tflog.Warn(ctx, "Error closing response body", map[string]any{
+				"error":  err.Error(),
+				"method": req.Method,
+				"url":    req.URL.String(),
+			})
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		var errorResp errorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
+			return nil, fmt.Errorf("error listing networks: failed to decode error response: %w", err)
+		}
+		return nil, fmt.Errorf("error listing networks: %q", errorResp.ErrorMsg)
+	}
+
+	var networks []Network
+	if err := json.NewDecoder(resp.Body).Decode(&networks); err != nil {
+		return nil, err
+	}
+
+	return networks, nil
+}
+
+// GetNetwork retrieves a specific network definition.
+func (client *PowerDNSClient) GetNetwork(ctx context.Context, ip, prefixlen string) (*Network, error) {
+	req, err := client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/servers/localhost/networks/%s/%s", ip, prefixlen), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			tflog.Warn(ctx, "Error closing response body", map[string]any{
+				"error":      err.Error(),
+				"method":     req.Method,
+				"url":        req.URL.String(),
+				"ip":         ip,
+				"prefix_len": prefixlen,
+			})
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var network Network
+		if err := json.NewDecoder(resp.Body).Decode(&network); err != nil {
+			return nil, err
+		}
+		return &network, nil
+	case http.StatusNotFound:
+		return nil, ErrNotFound
+	default:
+		var errorResp errorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
+			return nil, fmt.Errorf("error getting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
+		}
+		return nil, fmt.Errorf("error getting network %s/%s: %q", ip, prefixlen, errorResp.ErrorMsg)
+	}
+}
+
+// SetNetwork creates or updates a network definition.
+func (client *PowerDNSClient) SetNetwork(ctx context.Context, ip, prefixlen, view string) error {
+	body, err := json.Marshal(Network{View: view})
+	if err != nil {
+		return err
+	}
+
+	req, err := client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/servers/localhost/networks/%s/%s", ip, prefixlen), body)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			tflog.Warn(ctx, "Error closing response body", map[string]any{
+				"error":      err.Error(),
+				"method":     req.Method,
+				"url":        req.URL.String(),
+				"ip":         ip,
+				"prefix_len": prefixlen,
+				"view":       view,
+			})
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
+		var errorResp errorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
+			return fmt.Errorf("error setting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
+		}
+		return fmt.Errorf("error setting network %s/%s: %q", ip, prefixlen, errorResp.ErrorMsg)
+	}
+
+	return nil
+}
+
+// DeleteNetwork deletes a network definition.
+func (client *PowerDNSClient) DeleteNetwork(ctx context.Context, ip, prefixlen string) error {
+	body, err := json.Marshal(Network{View: ""})
+	if err != nil {
+		return err
+	}
+
+	req, err := client.newRequest(ctx, http.MethodPut, fmt.Sprintf("/servers/localhost/networks/%s/%s", ip, prefixlen), body)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			tflog.Warn(ctx, "Error closing response body", map[string]any{
+				"error":      err.Error(),
+				"method":     req.Method,
+				"url":        req.URL.String(),
+				"ip":         ip,
+				"prefix_len": prefixlen,
+			})
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		return ErrNotFound
+	default:
+		var errorResp errorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
+			return fmt.Errorf("error deleting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
+		}
+		return fmt.Errorf("error deleting network %s/%s: %q", ip, prefixlen, errorResp.ErrorMsg)
+	}
 }
 
 // RecursorClient talks to the PowerDNS Recursor API.

--- a/powerdns/client_views_networks_test.go
+++ b/powerdns/client_views_networks_test.go
@@ -1,0 +1,186 @@
+package powerdns
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetView(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/servers/localhost/views/test-view", r.URL.Path)
+		return jsonResponse(http.StatusOK, `{"id":"test-view","name":"test-view","zones":[]}`), nil
+	})
+
+	view, err := client.GetView(context.Background(), "test-view")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "test-view", view.Name)
+	assert.Empty(t, view.Zones)
+}
+
+func TestGetViewWithZoneAssociations(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/servers/localhost/views/test-view", r.URL.Path)
+		return jsonResponse(http.StatusOK, `{"id":"test-view","name":"test-view","zones":["example.com.","example.com..internal"]}`), nil
+	})
+
+	view, err := client.GetView(context.Background(), "test-view")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "test-view", view.Name)
+	assert.Equal(t, []string{"example.com.", "example.com..internal"}, view.Zones)
+}
+
+func TestGetViewNotFound(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, `{"error":"not found"}`), nil
+	})
+
+	view, err := client.GetView(context.Background(), "missing")
+	assert.Nil(t, view)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestGetViewErrorDecodeIncludesRootCause(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusInternalServerError, `not-json`), nil
+	})
+
+	view, err := client.GetView(context.Background(), "test-view")
+	assert.Nil(t, view)
+	assert.ErrorContains(t, err, "failed to decode error response")
+}
+
+func TestAddZoneToView(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/servers/localhost/views/test-view", r.URL.Path)
+
+		reqBody, err := io.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			return nil, err
+		}
+		defer func() {
+			err := r.Body.Close()
+			assert.NoError(t, err)
+		}()
+
+		var req map[string]string
+		err = json.NewDecoder(bytes.NewReader(reqBody)).Decode(&req)
+		if !assert.NoError(t, err) {
+			return nil, err
+		}
+		assert.Equal(t, "example.com.", req["name"])
+		return jsonResponse(http.StatusCreated, ``), nil
+	})
+
+	err := client.AddZoneToView(context.Background(), "test-view", "example.com.")
+	assert.NoError(t, err)
+}
+
+func TestRemoveZoneFromView(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/servers/localhost/views/test-view/example.com.", r.URL.Path)
+		return jsonResponse(http.StatusNoContent, ``), nil
+	})
+
+	err := client.RemoveZoneFromView(context.Background(), "test-view", "example.com.")
+	assert.NoError(t, err)
+}
+
+func TestGetNetwork(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/servers/localhost/networks/192.0.2.0/24", r.URL.Path)
+		return jsonResponse(http.StatusOK, `{"network":"192.0.2.0/24","view":"blue"}`), nil
+	})
+
+	network, err := client.GetNetwork(context.Background(), "192.0.2.0", "24")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "192.0.2.0/24", network.Network)
+	assert.Equal(t, "blue", network.View)
+}
+
+func TestListNetworks(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/servers/localhost/networks", r.URL.Path)
+		return jsonResponse(http.StatusOK, `[{"network":"192.0.2.0/24","view":"blue"},{"network":"2001:db8::/32","view":"green"}]`), nil
+	})
+
+	networks, err := client.ListNetworks(context.Background())
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, []Network{
+		{Network: "192.0.2.0/24", View: "blue"},
+		{Network: "2001:db8::/32", View: "green"},
+	}, networks)
+}
+
+func TestSetNetwork(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/servers/localhost/networks/192.0.2.0/24", r.URL.Path)
+
+		reqBody, err := io.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			return nil, err
+		}
+		defer func() {
+			err := r.Body.Close()
+			assert.NoError(t, err)
+		}()
+
+		var req Network
+		err = json.NewDecoder(bytes.NewReader(reqBody)).Decode(&req)
+		if !assert.NoError(t, err) {
+			return nil, err
+		}
+		assert.Equal(t, "blue", req.View)
+		return jsonResponse(http.StatusNoContent, ``), nil
+	})
+
+	err := client.SetNetwork(context.Background(), "192.0.2.0", "24", "blue")
+	assert.NoError(t, err)
+}
+
+func TestDeleteNetwork(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/servers/localhost/networks/192.0.2.0/24", r.URL.Path)
+
+		reqBody, err := io.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			return nil, err
+		}
+		defer func() {
+			err := r.Body.Close()
+			assert.NoError(t, err)
+		}()
+
+		var req Network
+		err = json.NewDecoder(bytes.NewReader(reqBody)).Decode(&req)
+		if !assert.NoError(t, err) {
+			return nil, err
+		}
+		assert.Equal(t, "", req.View)
+		return jsonResponse(http.StatusNoContent, ``), nil
+	})
+
+	err := client.DeleteNetwork(context.Background(), "192.0.2.0", "24")
+	assert.NoError(t, err)
+}

--- a/powerdns/data_source_powerdns_record_soa.go
+++ b/powerdns/data_source_powerdns_record_soa.go
@@ -17,7 +17,7 @@ func dataSourcePDNSRecordSOA() *schema.Resource {
 			"zone": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: ValidateFQDN,
+				ValidateFunc: ValidateZoneName,
 				Description:  "The name of the zone containing the SOA record. Must be a fully qualified domain name ending with a trailing dot.",
 			},
 			"name": {

--- a/powerdns/data_source_powerdns_zone.go
+++ b/powerdns/data_source_powerdns_zone.go
@@ -18,8 +18,8 @@ func dataSourcePDNSZone() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: ValidateFQDN,
-				Description:  "The name of the zone to retrieve. Must be a fully qualified domain name ending with a trailing dot.",
+				ValidateFunc: ValidateZoneName,
+				Description:  "The name of the zone to retrieve. Must be a fully qualified domain name ending with a trailing dot or zone variant.",
 			},
 			"kind": {
 				Type:        schema.TypeString,

--- a/powerdns/data_source_powerdns_zone_metadata.go
+++ b/powerdns/data_source_powerdns_zone_metadata.go
@@ -17,7 +17,7 @@ func dataSourcePDNSZoneMetadata() *schema.Resource {
 			"zone": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: ValidateFQDN,
+				ValidateFunc: ValidateZoneName,
 				Description:  "Zone name, as FQDN with trailing dot.",
 			},
 			"kind": {

--- a/powerdns/data_source_powerdns_zone_metadata_list.go
+++ b/powerdns/data_source_powerdns_zone_metadata_list.go
@@ -17,7 +17,7 @@ func dataSourcePDNSZoneMetadataList() *schema.Resource {
 			"zone": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: ValidateFQDN,
+				ValidateFunc: ValidateZoneName,
 				Description:  "Zone name, as FQDN with trailing dot.",
 			},
 			"entries": {

--- a/powerdns/ip.go
+++ b/powerdns/ip.go
@@ -7,12 +7,97 @@ import (
 	"strings"
 )
 
+func validateViewName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if value == "" {
+		errors = append(errors, fmt.Errorf("%q must be non-empty", k))
+		return
+	}
+	if strings.HasPrefix(value, ".") || strings.HasPrefix(value, " ") {
+		errors = append(errors, fmt.Errorf("%q must not start with a dot or a space, got: %s", k, value))
+		return
+	}
+
+	for _, ch := range value {
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' || ch == '.' || ch == ' ' {
+			continue
+		}
+		errors = append(errors, fmt.Errorf("%q may contain only letters, digits, spaces, dash, dot and underscore, got: %s", k, value))
+		break
+	}
+
+	return
+}
+
 // ValidateFQDN validates that a string is a fully qualified domain name ending with a trailing dot.
 func ValidateFQDN(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !strings.HasSuffix(value, ".") {
 		errors = append(errors, fmt.Errorf("%q must be a fully qualified domain name ending with a trailing dot (e.g., \"example.com.\"), got: %s", k, value))
 	}
+	return
+}
+
+// ValidateZoneName validates a PowerDNS zone name, including PowerDNS view variants.
+//
+// Accepted forms:
+//   - standard zone FQDN with trailing dot, e.g. `example.com.`
+//   - PowerDNS zone variant, e.g. `example.com..internal`
+//   - root zone variant, e.g. `..variant`
+//
+// Variant names must contain only lowercase letters, digits, underscore and dash.
+func ValidateZoneName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if value == "." {
+		return
+	}
+
+	if !strings.Contains(value, "..") {
+		return ValidateFQDN(v, k)
+	}
+
+	if strings.Count(value, "..") > 1 {
+		errors = append(errors, fmt.Errorf("%q must contain only one variant separator '..', got: %s", k, value))
+		return
+	}
+
+	parts := strings.SplitN(value, "..", 2)
+	if len(parts) != 2 {
+		errors = append(errors, fmt.Errorf("%q must be a fully qualified domain name ending with a trailing dot or a PowerDNS zone variant (e.g., \"example.com.\" or \"example.com..internal\"), got: %s", k, value))
+		return
+	}
+
+	base := parts[0]
+	variant := parts[1]
+
+	if strings.Contains(base, "..") {
+		errors = append(errors, fmt.Errorf("%q variant base must not contain an additional variant separator, got: %s", k, value))
+	}
+
+	if base == "" {
+		// root zone variant like `..variant`
+	} else if strings.HasSuffix(base, ".") {
+		errors = append(errors, fmt.Errorf("%q variant base must not end with a trailing dot before splitting, got: %s", k, value))
+	}
+
+	if variant == "" {
+		errors = append(errors, fmt.Errorf("%q variant name must be non-empty, got: %s", k, value))
+		return
+	}
+	if strings.HasSuffix(variant, ".") {
+		errors = append(errors, fmt.Errorf("%q variant name must not end with a dot, got: %s", k, value))
+		return
+	}
+
+	for _, ch := range variant {
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' {
+			continue
+		}
+		errors = append(errors, fmt.Errorf("%q variant name may contain only lowercase letters, digits, underscore and dash, got: %s", k, value))
+		break
+	}
+
 	return
 }
 

--- a/powerdns/ip_test.go
+++ b/powerdns/ip_test.go
@@ -2,6 +2,66 @@ package powerdns
 
 import "testing"
 
+func TestValidateViewName(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		expectError bool
+	}{
+		{name: "Valid lowercase", value: "internal", expectError: false},
+		{name: "Valid uppercase", value: "Internal", expectError: false},
+		{name: "Valid with dash", value: "internal-view", expectError: false},
+		{name: "Valid with dot", value: "internal.view", expectError: false},
+		{name: "Valid with underscore", value: "internal_view", expectError: false},
+		{name: "Valid with space", value: "internal view", expectError: false},
+		{name: "Invalid empty", value: "", expectError: true},
+		{name: "Invalid starts with dot", value: ".internal", expectError: true},
+		{name: "Invalid starts with space", value: " internal", expectError: true},
+		{name: "Invalid slash", value: "internal/view", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, errs := validateViewName(tt.value, "view")
+			if tt.expectError && len(errs) == 0 {
+				t.Errorf("validateViewName(%q) expected error but got none", tt.value)
+			}
+			if !tt.expectError && len(errs) > 0 {
+				t.Errorf("validateViewName(%q) unexpected error: %v", tt.value, errs)
+			}
+		})
+	}
+}
+
+func TestValidateZoneName(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		expectError bool
+	}{
+		{name: "Valid FQDN", value: "example.com.", expectError: false},
+		{name: "Valid variant", value: "example.com..internal", expectError: false},
+		{name: "Valid root variant", value: "..internal", expectError: false},
+		{name: "Invalid missing trailing dot", value: "example.com", expectError: true},
+		{name: "Invalid variant ending with dot", value: "example.com..internal.", expectError: true},
+		{name: "Invalid multiple variant separators", value: "example.com..internal..blue", expectError: true},
+		{name: "Invalid variant uppercase", value: "example.com..Internal", expectError: true},
+		{name: "Invalid base with trailing dot before variant", value: "example.com...internal", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, errs := ValidateZoneName(tt.value, "name")
+			if tt.expectError && len(errs) == 0 {
+				t.Errorf("ValidateZoneName(%q) expected error but got none", tt.value)
+			}
+			if !tt.expectError && len(errs) > 0 {
+				t.Errorf("ValidateZoneName(%q) unexpected error: %v", tt.value, errs)
+			}
+		})
+	}
+}
+
 func TestValidateFQDN(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/powerdns/provider.go
+++ b/powerdns/provider.go
@@ -82,6 +82,8 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"powerdns_zone":                  resourcePDNSZone(),
+			"powerdns_view_zone_association": resourcePDNSViewZoneAssociation(),
+			"powerdns_network":               resourcePDNSNetwork(),
 			"powerdns_zone_metadata":         resourcePDNSZoneMetadata(),
 			"powerdns_record":                resourcePDNSRecord(),
 			"powerdns_record_soa":            resourcePDNSRecordSOA(),

--- a/powerdns/resource_powerdns_network.go
+++ b/powerdns/resource_powerdns_network.go
@@ -1,0 +1,127 @@
+package powerdns
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourcePDNSNetwork() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePDNSNetworkCreate,
+		ReadContext:   resourcePDNSNetworkRead,
+		UpdateContext: resourcePDNSNetworkUpdate,
+		DeleteContext: resourcePDNSNetworkDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"network": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsCIDR,
+			},
+			"view": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateViewName,
+			},
+		},
+	}
+}
+
+func parseNetworkCIDR(network string) (string, string, error) {
+	ip, ipnet, err := net.ParseCIDR(network)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid network format: %w", err)
+	}
+	prefixlen, _ := ipnet.Mask.Size()
+	return ip.String(), strconv.Itoa(prefixlen), nil
+}
+
+func resourcePDNSNetworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourcePDNSNetworkUpsert(ctx, d, meta)
+}
+
+func resourcePDNSNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourcePDNSNetworkUpsert(ctx, d, meta)
+}
+
+func resourcePDNSNetworkUpsert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*ProviderClients)
+	network := d.Get("network").(string)
+	view := d.Get("view").(string)
+
+	ip, prefixlen, err := parseNetworkCIDR(network)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.SetField(ctx, "network", network)
+	tflog.SetField(ctx, "view", view)
+	tflog.Debug(ctx, "Creating or updating PowerDNS network")
+
+	if err := client.PDNS.SetNetwork(ctx, ip, prefixlen, view); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to set network %s: %w", network, err))
+	}
+
+	d.SetId(network)
+	return resourcePDNSNetworkRead(ctx, d, meta)
+}
+
+func resourcePDNSNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*ProviderClients)
+	networkCIDR := d.Id()
+
+	ip, prefixlen, err := parseNetworkCIDR(networkCIDR)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.SetField(ctx, "network", networkCIDR)
+	tflog.Debug(ctx, "Reading PowerDNS network")
+
+	network, err := client.PDNS.GetNetwork(ctx, ip, prefixlen)
+	if err != nil {
+		if err == ErrNotFound {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("failed to get network %s: %w", networkCIDR, err))
+	}
+
+	if err := d.Set("network", network.Network); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting network: %w", err))
+	}
+	if err := d.Set("view", network.View); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting view: %w", err))
+	}
+
+	return nil
+}
+
+func resourcePDNSNetworkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*ProviderClients)
+	networkCIDR := d.Id()
+
+	ip, prefixlen, err := parseNetworkCIDR(networkCIDR)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.SetField(ctx, "network", networkCIDR)
+	tflog.Debug(ctx, "Deleting PowerDNS network")
+
+	if err := client.PDNS.DeleteNetwork(ctx, ip, prefixlen); err != nil && err != ErrNotFound {
+		return diag.FromErr(fmt.Errorf("failed to delete network %s: %w", networkCIDR, err))
+	}
+
+	return nil
+}

--- a/powerdns/resource_powerdns_network_test.go
+++ b/powerdns/resource_powerdns_network_test.go
@@ -1,0 +1,93 @@
+package powerdns
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestParseNetworkCIDR(t *testing.T) {
+	ip, prefix, err := parseNetworkCIDR("192.0.2.0/24")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip != "192.0.2.0" || prefix != "24" {
+		t.Fatalf("unexpected result: %s/%s", ip, prefix)
+	}
+}
+
+func TestAccPDNSNetworkBasic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPDNSNetworkConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerdns_network.test", "network", "192.0.2.0/24"),
+					resource.TestCheckResourceAttr("powerdns_network.test", "view", "test-network-view"),
+				),
+			},
+			{
+				ResourceName:      "powerdns_network.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPDNSNetworkInvalidNetwork(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPDNSNetworkConfigInvalidNetwork,
+				ExpectError: regexp.MustCompile("invalid CIDR"),
+			},
+		},
+	})
+}
+
+func TestAccPDNSNetworkInvalidView(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPDNSNetworkConfigInvalidView,
+				ExpectError: regexp.MustCompile("must not start with a dot or a space"),
+			},
+		},
+	})
+}
+
+const testAccPDNSNetworkConfigBasic = `
+resource "powerdns_zone" "test" {
+  name = "network-test.example."
+  kind = "Native"
+}
+
+resource "powerdns_view_zone_association" "test" {
+  view = "test-network-view"
+  zone = powerdns_zone.test.name
+}
+
+resource "powerdns_network" "test" {
+  network = "192.0.2.0/24"
+  view    = powerdns_view_zone_association.test.view
+}`
+
+const testAccPDNSNetworkConfigInvalidNetwork = `
+resource "powerdns_network" "test" {
+  network = "not-a-cidr"
+  view    = "internal"
+}`
+
+const testAccPDNSNetworkConfigInvalidView = `
+resource "powerdns_network" "test" {
+  network = "192.0.2.0/24"
+  view    = ".invalid-view"
+}`

--- a/powerdns/resource_powerdns_record.go
+++ b/powerdns/resource_powerdns_record.go
@@ -27,7 +27,7 @@ func resourcePDNSRecord() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: ValidateFQDN,
+				ValidateFunc: ValidateZoneName,
 			},
 			"name": {
 				Type:         schema.TypeString,

--- a/powerdns/resource_powerdns_record_soa.go
+++ b/powerdns/resource_powerdns_record_soa.go
@@ -28,7 +28,7 @@ func resourcePDNSRecordSOA() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: ValidateFQDN,
+				ValidateFunc: ValidateZoneName,
 			},
 			"name": {
 				Type:         schema.TypeString,

--- a/powerdns/resource_powerdns_view_zone_association.go
+++ b/powerdns/resource_powerdns_view_zone_association.go
@@ -1,0 +1,134 @@
+package powerdns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourcePDNSViewZoneAssociation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePDNSViewZoneAssociationCreate,
+		ReadContext:   resourcePDNSViewZoneAssociationRead,
+		DeleteContext: resourcePDNSViewZoneAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePDNSViewZoneAssociationImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"view": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateViewName,
+			},
+			"zone": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: ValidateZoneName,
+			},
+		},
+	}
+}
+
+func viewZoneAssociationID(view string, zone string) string {
+	return view + idSeparator + zone
+}
+
+func parseViewZoneAssociationID(id string) (string, string, error) {
+	parts := strings.Split(id, idSeparator)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid view zone association id %q, expected <view>%s<zone>", id, idSeparator)
+	}
+	return parts[0], parts[1], nil
+}
+
+func resourcePDNSViewZoneAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*ProviderClients)
+	view := d.Get("view").(string)
+	zone := d.Get("zone").(string)
+
+	tflog.SetField(ctx, "view", view)
+	tflog.SetField(ctx, "zone", zone)
+	tflog.Debug(ctx, "Creating PowerDNS view zone association")
+
+	if err := client.PDNS.AddZoneToView(ctx, view, zone); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to add zone %s to view %s: %w", zone, view, err))
+	}
+
+	d.SetId(viewZoneAssociationID(view, zone))
+	return resourcePDNSViewZoneAssociationRead(ctx, d, meta)
+}
+
+func resourcePDNSViewZoneAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*ProviderClients)
+	view, zone, err := parseViewZoneAssociationID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.SetField(ctx, "view", view)
+	tflog.SetField(ctx, "zone", zone)
+	tflog.Debug(ctx, "Reading PowerDNS view zone association")
+
+	pdnsView, err := client.PDNS.GetView(ctx, view)
+	if err != nil {
+		if err == ErrNotFound {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("failed to get view %s: %w", view, err))
+	}
+
+	for _, existingZone := range pdnsView.Zones {
+		if existingZone == zone {
+			if err := d.Set("view", view); err != nil {
+				return diag.FromErr(fmt.Errorf("error setting view: %w", err))
+			}
+			if err := d.Set("zone", zone); err != nil {
+				return diag.FromErr(fmt.Errorf("error setting zone: %w", err))
+			}
+			return nil
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourcePDNSViewZoneAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*ProviderClients)
+	view, zone, err := parseViewZoneAssociationID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.SetField(ctx, "view", view)
+	tflog.SetField(ctx, "zone", zone)
+	tflog.Debug(ctx, "Deleting PowerDNS view zone association")
+
+	if err := client.PDNS.RemoveZoneFromView(ctx, view, zone); err != nil && err != ErrNotFound {
+		return diag.FromErr(fmt.Errorf("failed to remove zone %s from view %s: %w", zone, view, err))
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourcePDNSViewZoneAssociationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	view, zone, err := parseViewZoneAssociationID(d.Id())
+	if err != nil {
+		return nil, err
+	}
+	if err := d.Set("view", view); err != nil {
+		return nil, err
+	}
+	if err := d.Set("zone", zone); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/powerdns/resource_powerdns_view_zone_association_test.go
+++ b/powerdns/resource_powerdns_view_zone_association_test.go
@@ -1,0 +1,140 @@
+package powerdns
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccPDNSViewZoneAssociationBasic(t *testing.T) {
+	resourceName := "powerdns_view_zone_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(s *terraform.State) error {
+			return testAccCheckPDNSViewZoneAssociationDestroy(s)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPDNSViewZoneAssociationConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "view", "test-association-view"),
+					resource.TestCheckResourceAttr(resourceName, "zone", "association.example."),
+					testAccCheckPDNSViewContainsZone("test-association-view", "association.example."),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPDNSViewZoneAssociationInvalidView(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPDNSViewZoneAssociationConfigInvalidView,
+				ExpectError: regexp.MustCompile("must not start with a dot or a space"),
+			},
+		},
+	})
+}
+
+func TestAccPDNSViewZoneAssociationInvalidZone(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPDNSViewZoneAssociationConfigInvalidZone,
+				ExpectError: regexp.MustCompile("variant name may contain only lowercase letters, digits, underscore and dash"),
+			},
+		},
+	})
+}
+
+func testAccCheckPDNSViewContainsZone(viewName string, zoneName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*ProviderClients).PDNS
+		view, err := client.GetView(context.Background(), viewName)
+		if err != nil {
+			return fmt.Errorf("error getting view %s: %w", viewName, err)
+		}
+
+		for _, zone := range view.Zones {
+			if zone == zoneName {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("view %s missing zone %s in %v", viewName, zoneName, view.Zones)
+	}
+}
+
+func testAccCheckPDNSViewZoneAssociationDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "powerdns_view_zone_association" {
+			continue
+		}
+
+		viewName := rs.Primary.Attributes["view"]
+		zoneName := rs.Primary.Attributes["zone"]
+		if viewName == "" || zoneName == "" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*ProviderClients).PDNS
+		view, err := client.GetView(context.Background(), viewName)
+		if err != nil {
+			if err == ErrNotFound {
+				continue
+			}
+			return fmt.Errorf("error getting view %s: %w", viewName, err)
+		}
+
+		for _, zone := range view.Zones {
+			if zone == zoneName {
+				return fmt.Errorf("view zone association still exists: view %s zone %s", viewName, zoneName)
+			}
+		}
+	}
+	return nil
+}
+
+const testAccPDNSViewZoneAssociationConfigBasic = `
+resource "powerdns_zone" "test" {
+  name = "association.example."
+  kind = "Native"
+}
+
+resource "powerdns_view_zone_association" "test" {
+  view = "test-association-view"
+  zone = powerdns_zone.test.name
+}`
+
+const testAccPDNSViewZoneAssociationConfigInvalidView = `
+resource "powerdns_zone" "test" {
+  name = "invalid-association-view.example."
+  kind = "Native"
+}
+
+resource "powerdns_view_zone_association" "test" {
+  view = ".invalid-association-view"
+  zone = powerdns_zone.test.name
+}`
+
+const testAccPDNSViewZoneAssociationConfigInvalidZone = `
+resource "powerdns_view_zone_association" "test" {
+  view = "test-association-view"
+  zone = "association.example..BadVariant"
+}`

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -29,7 +29,7 @@ func resourcePDNSZone() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: ValidateFQDN,
+				ValidateFunc: ValidateZoneName,
 			},
 
 			"kind": {
@@ -46,6 +46,13 @@ func resourcePDNSZone() *schema.Resource {
 				Default:      "admin",
 				ForceNew:     false,
 				ValidateFunc: validation.StringLenBetween(0, 40),
+			},
+
+			"catalog": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     false,
+				ValidateFunc: ValidateZoneName,
 			},
 
 			"masters": {
@@ -94,6 +101,7 @@ func resourcePDNSZoneCreate(ctx context.Context, d *schema.ResourceData, meta in
 	zoneInfo := ZoneInfo{
 		Name:        d.Get("name").(string),
 		Kind:        d.Get("kind").(string),
+		Catalog:     d.Get("catalog").(string),
 		Account:     d.Get("account").(string),
 		Nameservers: []string{},
 		SoaEditAPI:  d.Get("soa_edit_api").(string),
@@ -147,6 +155,9 @@ func resourcePDNSZoneRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if err := d.Set("account", zoneInfo.Account); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting PowerDNS Account: %w", err))
 	}
+	if err := d.Set("catalog", zoneInfo.Catalog); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting PowerDNS Catalog: %w", err))
+	}
 	if err := d.Set("soa_edit_api", zoneInfo.SoaEditAPI); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting PowerDNS SOA Edit API: %w", err))
 	}
@@ -166,7 +177,7 @@ func resourcePDNSZoneUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	client := meta.(*ProviderClients)
 
-	if d.HasChange("kind") || d.HasChange("account") || d.HasChange("soa_edit_api") || d.HasChange("masters") {
+	if d.HasChange("kind") || d.HasChange("account") || d.HasChange("catalog") || d.HasChange("soa_edit_api") || d.HasChange("masters") {
 		var masters []string
 		for _, m := range d.Get("masters").(*schema.Set).List() {
 			masters = append(masters, m.(string))
@@ -175,6 +186,7 @@ func resourcePDNSZoneUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		zoneInfo := ZoneInfoUpd{
 			Name:       d.Get("name").(string),
 			Kind:       d.Get("kind").(string),
+			Catalog:    d.Get("catalog").(string),
 			Account:    d.Get("account").(string),
 			SoaEditAPI: d.Get("soa_edit_api").(string),
 			Masters:    masters,

--- a/powerdns/resource_powerdns_zone_metadata.go
+++ b/powerdns/resource_powerdns_zone_metadata.go
@@ -26,7 +26,7 @@ func resourcePDNSZoneMetadata() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: ValidateFQDN,
+				ValidateFunc: ValidateZoneName,
 				Description:  "Zone name, for example \"example.com.\".",
 			},
 			"kind": {

--- a/powerdns/resource_powerdns_zone_test.go
+++ b/powerdns/resource_powerdns_zone_test.go
@@ -212,6 +212,32 @@ func TestAccPDNSZoneAccount(t *testing.T) {
 	})
 }
 
+func TestAccPDNSZoneCatalog(t *testing.T) {
+	resourceName := "powerdns_zone.test-catalog"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPDNSZoneConfigCatalog,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPDNSZoneExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "catalog.sysa.abc."),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Master"),
+					resource.TestCheckResourceAttr(resourceName, "catalog", "catalog-a.example."),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccPDNSZoneAccountEmpty(t *testing.T) {
 	resourceName := "powerdns_zone.test-account-empty"
 	resourceAccount := ``
@@ -386,6 +412,58 @@ func TestAccPDNSZoneMasterWithMasters(t *testing.T) {
 	})
 }
 
+func TestAccPDNSZoneInvalidDomain(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testPDNSZoneConfigInvalidDomain,
+				ExpectError: regexp.MustCompile("fully qualified domain name ending with a trailing dot"),
+			},
+		},
+	})
+}
+
+func TestAccPDNSZoneInvalidVariant(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testPDNSZoneConfigInvalidVariant,
+				ExpectError: regexp.MustCompile("variant name may contain only lowercase letters"),
+			},
+		},
+	})
+}
+
+func TestAccPDNSZoneInvalidVariantTrailingDot(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testPDNSZoneConfigInvalidVariantTrailingDot,
+				ExpectError: regexp.MustCompile("variant name must not end with a dot"),
+			},
+		},
+	})
+}
+
+func TestAccPDNSZoneInvalidVariantMultipleSeparators(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testPDNSZoneConfigInvalidVariantMultipleSeparators,
+				ExpectError: regexp.MustCompile("only one variant separator"),
+			},
+		},
+	})
+}
+
 func testAccCheckPDNSZoneDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "powerdns_zone" {
@@ -448,6 +526,30 @@ resource "powerdns_zone" "test-master" {
 	kind = "Master"
 }`
 
+const testPDNSZoneConfigInvalidDomain = `
+resource "powerdns_zone" "test-invalid-domain" {
+	name = "invalid.example.com"
+	kind = "Native"
+}`
+
+const testPDNSZoneConfigInvalidVariant = `
+resource "powerdns_zone" "test-invalid-variant" {
+	name = "invalid.example.com..BadVariant"
+	kind = "Native"
+}`
+
+const testPDNSZoneConfigInvalidVariantTrailingDot = `
+resource "powerdns_zone" "test-invalid-variant-trailing-dot" {
+	name = "invalid.example.com..variant."
+	kind = "Native"
+}`
+
+const testPDNSZoneConfigInvalidVariantMultipleSeparators = `
+resource "powerdns_zone" "test-invalid-variant-multiple-separators" {
+	name = "invalid.example.com..variant..blue"
+	kind = "Native"
+}`
+
 const testPDNSZoneConfigMasterSOAEDITAPI = `
 resource "powerdns_zone" "test-master-soa-edit-api" {
 	name = "master-soa-edit-api.sysa.abc."
@@ -493,6 +595,13 @@ const testPDNSZoneConfigSlave = `
 resource "powerdns_zone" "test-slave" {
 	name = "slave.sysa.abc."
 	kind = "Slave"
+}`
+
+const testPDNSZoneConfigCatalog = `
+resource "powerdns_zone" "test-catalog" {
+	name    = "catalog.sysa.abc."
+	kind    = "Master"
+	catalog = "catalog-a.example."
 }`
 
 const testPDNSZoneConfigSlaveWithMasters = `

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "powerdns"
+page_title: "PowerDNS: powerdns_network"
+sidebar_current: "docs-powerdns-resource-network"
+description: |-
+  Manages PowerDNS authoritative network-to-view mappings.
+---
+
+# powerdns_network
+
+Manages one PowerDNS authoritative network-to-view mapping.
+
+PowerDNS networks map client source networks to views. Use this resource together with `powerdns_view` to route clients from a CIDR range to a specific view.
+
+## Example Usage
+
+```hcl
+resource "powerdns_zone" "internal" {
+  name = "internal.example.com."
+  kind = "Native"
+}
+
+resource "powerdns_view_zone_association" "internal" {
+  view = "internal"
+  zone = powerdns_zone.internal.name
+}
+
+resource "powerdns_network" "internal_clients" {
+  network = "192.0.2.0/24"
+  view    = powerdns_view_zone_association.internal.view
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `network` - (Required, Forces new resource) Client source network in CIDR notation, for example `192.0.2.0/24` or `2001:db8::/32`.
+- `view` - (Required) Name of the PowerDNS view assigned to the network.
+
+## Importing
+
+Import using the network CIDR.
+
+Example:
+
+```bash
+terraform import powerdns_network.internal_clients '192.0.2.0/24'
+```

--- a/website/docs/r/view_zone_association.html.markdown
+++ b/website/docs/r/view_zone_association.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "powerdns"
+page_title: "PowerDNS: powerdns_view_zone_association"
+sidebar_current: "docs-powerdns-resource-view-zone-association"
+description: |-
+  Manages one PowerDNS authoritative view-to-zone association.
+---
+
+# powerdns_view_zone_association
+
+Manages one PowerDNS authoritative view-to-zone association.
+
+Use this resource together with `powerdns_view` to manage each zone membership independently. This is useful when multiple Terraform resources need to add or remove zones from the same view without replacing the whole view membership set.
+
+## Example Usage
+
+```hcl
+resource "powerdns_zone" "private" {
+  name = "private.example."
+  kind = "Native"
+}
+
+resource "powerdns_view_zone_association" "private" {
+  view = "internal"
+  zone = powerdns_zone.private.name
+}
+```
+
+## Argument Reference
+
+- `view` - (Required, Forces new resource) Name of the PowerDNS view.
+- `zone` - (Required, Forces new resource) Name of the zone to associate with the view. This may be a normal FQDN zone such as `example.com.` or a variant zone such as `example.com..internal`.
+
+## Importing
+
+Import using the view name, three colons (`:::`), and the zone name.
+
+```bash
+terraform import powerdns_view_zone_association.private 'internal:::private.example.'
+```

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -78,6 +78,24 @@ resource "powerdns_zone" "fubar" {
 }
 ```
 
+```hcl
+# Create a catalog zone.
+resource "powerdns_zone" "catalog" {
+  name = "catalog-a.example."
+  kind = "Producer"
+}
+
+```
+
+```hcl
+# Add a zone to a catalog zone.
+resource "powerdns_zone" "catalog_member" {
+  name    = "catalog-member.example.com."
+  kind    = "Master"
+  catalog = "catalog-a.example."
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -85,6 +103,7 @@ This resource supports the following arguments:
 - `name` - (Required) The name of zone. Must be a fully qualified domain name (FQDN) ending with a trailing dot (e.g., `"example.com."`).
 - `kind` - (Required) The kind of the zone.
 - `account` - (Optional) The account owning the zone. (Default to "admin")
+- `catalog` - (Optional) Catalog zone FQDN, ending with a trailing dot, to assign this zone to. This can be used to create or update PowerDNS catalog zone membership.
 - `masters` - (Optional) List of IP addresses configured as a master for this zone. This argument must be provided when `kind` is set to `Slave`.
 - `soa_edit_api` - (Optional) This should map to one of the [supported API values](https://doc.powerdns.com/authoritative/dnsupdate.html#soa-edit-dnsupdate-settings) *or* in [case you wish to remove the setting](https://doc.powerdns.com/authoritative/domainmetadata.html#soa-edit-api), set this argument as `""` (that will translate to the API value `""`).
 

--- a/website/powerdns.erb
+++ b/website/powerdns.erb
@@ -37,6 +37,9 @@
         <li<%= sidebar_current("docs-powerdns-resource") %>>
         <a href="#">Resources</a>
                 <ul class="nav nav-visible">
+                    <li<%= sidebar_current("docs-powerdns-resource-network") %>>
+          <a href="/docs/providers/powerdns/r/network.html">powerdns_network</a>
+                    </li>
                     <li<%= sidebar_current("docs-powerdns-resource-record") %>>
           <a href="/docs/providers/powerdns/r/record.html">powerdns_record</a>
                     </li>
@@ -48,6 +51,9 @@
                     </li>
                     <li<%= sidebar_current("docs-powerdns-resource-zone-metadata") %>>
           <a href="/docs/providers/powerdns/r/zone_metadata.html">powerdns_zone_metadata</a>
+                    </li>
+                    <li<%= sidebar_current("docs-powerdns-resource-view-zone-association") %>>
+          <a href="/docs/providers/powerdns/r/view_zone_association.html">powerdns_view_zone_association</a>
                     </li>
         </ul>
         </li>


### PR DESCRIPTION
Hello, i am using https://doc.powerdns.com/authoritative/views.html
Added:

1. Catalog support for zones (my recursor use it for zones forwarding towards Auth) 
2. VIews support
3. Networks support
4. Verification function for variant zones

Fixed:

1. Caching never reach powerdns (will fix another PR)
