### PR TITLE
Request rrsets when fetching zones and make Comment.account required in JSON

### DIFF
--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -253,7 +253,7 @@ type zonePatchRequest struct {
 // Comment represents a PowerDNS RRset comment.
 type Comment struct {
 	Content    string `json:"content"`
-	Account    string `json:"account,omitempty"`
+	Account    string `json:"account"`
 	ModifiedAt int64  `json:"modified_at,omitempty"`
 }
 
@@ -332,7 +332,7 @@ func (client *PowerDNSClient) ListZones(ctx context.Context) ([]ZoneInfo, error)
 
 // GetZone gets a zone
 func (client *PowerDNSClient) GetZone(ctx context.Context, name string) (ZoneInfo, error) {
-	req, err := client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/servers/localhost/zones/%s", name), nil)
+	req, err := client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/servers/localhost/zones/%s?rrsets=true", name), nil)
 	if err != nil {
 		return ZoneInfo{}, err
 	}
@@ -698,7 +698,7 @@ func (client *PowerDNSClient) ListRecords(ctx context.Context, zone string) ([]R
 	}
 
 	if zoneInfo == nil {
-		req, err := client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/servers/localhost/zones/%s", zone), nil)
+		req, err := client.newRequest(ctx, http.MethodGet, fmt.Sprintf("/servers/localhost/zones/%s?rrsets=true", zone), nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Motivation
- Ensure zone fetches include RRsets so consumers receive record sets in responses and align the `Comment` JSON schema with the API by making the `account` field always emitted.

### Description
- Append `?rrsets=true` to the zone GET requests in `GetZone` and `ListRecords` so the API returns RRsets with the zone payload.
- Change the `Comment.Account` struct tag from `json:"account,omitempty"` to `json:"account"` to stop omitting the field from serialized JSON.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c2b435d8832bb7abd5d6717ae9c1)