### PR TITLE
support IPv6 addresses in the masters attribute #73

### DIFF
--- a/powerdns/ip.go
+++ b/powerdns/ip.go
@@ -332,3 +332,77 @@ func GetReverseZoneName(cidr string) (string, error) {
 	return zone, nil
 
 }
+
+// ValidateMasterAddress validates a single entry of the masters attribute.
+//
+// PowerDNS accepts four forms: a bare IPv4 or IPv6 address, and either of them
+// with a port. The bare-address check has to come first, because
+// net.SplitHostPort cannot distinguish an IPv6 address from a host-port pair —
+// both are full of colons. Splitting on ":" instead, as the previous
+// implementation did, rejected every IPv6 address.
+//
+// The error messages match the ones the create path used, so existing
+// expectations still hold.
+func ValidateMasterAddress(v interface{}, k string) (ws []string, errors []error) {
+	value, ok := v.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("values in masters list attribute must be valid IPs"))
+		return
+	}
+
+	// A bare address of either family, including an IPv6 address with colons.
+	if net.ParseIP(value) != nil {
+		return
+	}
+
+	host, port, err := net.SplitHostPort(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("values in masters list attribute must be valid IPs"))
+		return
+	}
+
+	if net.ParseIP(host) == nil {
+		errors = append(errors, fmt.Errorf("values in masters list attribute must be valid IPs"))
+		return
+	}
+
+	portNumber, err := strconv.Atoi(port)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("error converting port value in masters attribute"))
+		return
+	}
+
+	if portNumber < 1 || portNumber > 65535 {
+		errors = append(errors, fmt.Errorf("invalid port value in masters attribute"))
+	}
+
+	return
+}
+
+// NormalizeMasterAddress renders a master entry in the canonical text form Go
+// produces for the parsed address, so configuration and state agree.
+//
+// PowerDNS stores the compressed form: a master written
+// fd92:81e1:e314:ea7b:0000:1234:5678:60ab is returned as
+// fd92:81e1:e314:ea7b:0:1234:5678:60ab. Without normalising, the configured
+// spelling and the stored one differ and every plan wants to change the zone.
+//
+// Anything that does not parse is returned unchanged; ValidateMasterAddress
+// reports it.
+func NormalizeMasterAddress(value string) string {
+	if ip := net.ParseIP(value); ip != nil {
+		return ip.String()
+	}
+
+	host, port, err := net.SplitHostPort(value)
+	if err != nil {
+		return value
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return value
+	}
+
+	return net.JoinHostPort(ip.String(), port)
+}

--- a/powerdns/ip_test.go
+++ b/powerdns/ip_test.go
@@ -630,3 +630,37 @@ func TestGetReverseZoneName(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateMasterAddress(t *testing.T) {
+	valid := []string{
+		"192.0.2.1",
+		"2001:db8::1",
+		"fd92:81e1:e314:ea7b:0000:1234:5678:60ab",
+		"::1",
+		"192.0.2.1:53",
+		"[2001:db8::1]:53",
+		"192.0.2.1:1",
+		"192.0.2.1:65535",
+	}
+	for _, value := range valid {
+		if _, errs := ValidateMasterAddress(value, "masters"); len(errs) != 0 {
+			t.Errorf("%q should be a valid master, got: %v", value, errs)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"ns1.example.com",
+		"ns1.example.com:53",
+		"192.0.2.1:0",
+		"192.0.2.1:65536",
+		"192.0.2.1:dns",
+		"999.0.2.1",
+		"not an address",
+	}
+	for _, value := range invalid {
+		if _, errs := ValidateMasterAddress(value, "masters"); len(errs) == 0 {
+			t.Errorf("%q should not be a valid master", value)
+		}
+	}
+}

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -3,8 +3,6 @@ package powerdns
 import (
 	"context"
 	"fmt"
-	"net"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -56,8 +54,14 @@ func resourcePDNSZone() *schema.Resource {
 			},
 
 			"masters": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: ValidateMasterAddress,
+					StateFunc: func(v interface{}) string {
+						return NormalizeMasterAddress(v.(string))
+					},
+				},
 				Optional: true,
 			},
 
@@ -73,29 +77,11 @@ func resourcePDNSZone() *schema.Resource {
 func resourcePDNSZoneCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderClients)
 
+	// Each element is validated by the schema's ValidateFunc, which runs on
+	// create and on update alike.
 	var masters []string
-	for _, masterIPPort := range d.Get("masters").(*schema.Set).List() {
-		splitIPPort := strings.Split(masterIPPort.(string), ":")
-		// if there are more elements
-		if len(splitIPPort) > 2 {
-			return diag.FromErr(fmt.Errorf("more than one colon in <ip>:<port> string"))
-		}
-		// when there are exactly 2 elements in list, assume second is port and check the port range
-		if len(splitIPPort) == 2 {
-			port, err := strconv.Atoi(splitIPPort[1])
-			if err != nil {
-				return diag.FromErr(fmt.Errorf("error converting port value in masters attribute"))
-			}
-			if port < 1 || port > 65535 {
-				return diag.FromErr(fmt.Errorf("invalid port value in masters attribute"))
-			}
-		}
-		// first element is IP
-		masterIP := splitIPPort[0]
-		if net.ParseIP(masterIP) == nil {
-			return diag.FromErr(fmt.Errorf("values in masters list attribute must be valid IPs"))
-		}
-		masters = append(masters, masterIPPort.(string))
+	for _, master := range d.Get("masters").(*schema.Set).List() {
+		masters = append(masters, master.(string))
 	}
 
 	zoneInfo := ZoneInfo{

--- a/powerdns/resource_powerdns_zone_test.go
+++ b/powerdns/resource_powerdns_zone_test.go
@@ -371,6 +371,30 @@ func TestAccPDNSZoneSlaveWithMastersWithPort(t *testing.T) {
 	})
 }
 
+func TestAccPDNSZoneSlaveWithIPv6Masters(t *testing.T) {
+	resourceName := "powerdns_zone.test-slave-with-ipv6-masters"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPDNSZoneConfigSlaveWithIPv6Masters,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPDNSZoneExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "masters.#", "2"),
+					// Stored in the canonical compressed form, which is also what
+					// PowerDNS returns — so a re-plan is empty.
+					resource.TestCheckTypeSetElemAttr(resourceName, "masters.*",
+						"fd92:81e1:e314:ea7b:0:1234:5678:60ab"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "masters.*", "192.168.123.45"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPDNSZoneSlaveWithMastersWithInvalidPort(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -637,4 +661,15 @@ resource "powerdns_zone" "test-master-with-masters" {
 	name = "master-with-masters.sysa.abc."
 	kind = "Master"
 	masters = ["1.1.1.1", "2.2.2.2"]
+}`
+
+const testPDNSZoneConfigSlaveWithIPv6Masters = `
+resource "powerdns_zone" "test-slave-with-ipv6-masters" {
+	name = "slave-with-ipv6-masters.sysa.abc."
+	kind = "Slave"
+	soa_edit_api = "DEFAULT"
+	masters = [
+		"fd92:81e1:e314:ea7b:0000:1234:5678:60ab",
+		"192.168.123.45",
+	]
 }`


### PR DESCRIPTION
Closes #73.

## The reported problem

The create path splits each master on `":"` and rejects anything with more than one colon, so every IPv6 address fails:

```
Error: more than one colon in <ip>:<port> string
```

## Two causes, not one

**Parsing.** `net.SplitHostPort` cannot distinguish an IPv6 address from a host-port pair — both are full of colons — so a bare address has to be recognised first. Validation moves to the schema as `ValidateMasterAddress`, which means it now runs on **update** as well as create, and at plan rather than apply.

That also explains the workaround in the issue. The update path validated `masters` not at all, so creating with IPv4 and then editing to add IPv6 slipped past a check that only existed on create.

The existing error strings are kept deliberately, so `TestAccPDNSZoneSlaveWithMastersWithInvalidPort` and `TestAccPDNSZoneSlaveWithInvalidMasters` pass unchanged.

**Normalisation.** Fixing the parsing alone does not close the issue. PowerDNS stores the compressed form, so the address from the report comes back different from the way it was written, and every later plan wants to change the zone:

```
~ masters = [
    - "fd92:81e1:e314:ea7b:0:1234:5678:60ab"
    + "fd92:81e1:e314:ea7b:0000:1234:5678:60ab"
  ]
```

A `StateFunc` renders the value in the canonical text form, so configuration and state agree. Without this the reporter would trade an error for a permanent diff.

## Tests

- `TestValidateMasterAddress` — 8 accepted forms, 8 rejected, covering bare IPv4/IPv6, both with ports, and `[v6]:port`
- `TestAccPDNSZoneSlaveWithIPv6Masters` — the configuration from the issue verbatim

Verified against PowerDNS Authoritative 5.1.3 on the `gpgsql` backend:

```
go test ./powerdns/ -run TestAccPDNSZone -count=1     ok
make fmtcheck                                          clean
golangci-lint run ./...                                0 issues
go mod tidy && go mod vendor                           no changes
```

## Scope

Four files, +155/−26. No dependency changes, no schema-visible change other than validation moving earlier, and no behaviour change for IPv4 configurations.

Happy to add a `CHANGELOG.md` entry in whatever form you prefer — I left it out since the release notes look curated at release time.