### PR TITLE
set an explicit TLS minimum version on the API client

### DIFF
--- a/powerdns/config.go
+++ b/powerdns/config.go
@@ -26,7 +26,13 @@ type Config struct {
 
 // Client returns a new client for accessing PowerDNS
 func (c *Config) Clients(ctx context.Context) (*PowerDNSClient, *RecursorClient, error) {
-	tlsConfig := &tls.Config{}
+	// Go's own minimum is already TLS 1.2, but leaving it implicit means the
+	// floor moves if that default ever changes. 1.2 rather than 1.3 because the
+	// PowerDNS API is often published through a front end that has not moved to
+	// 1.3, and failing to reach the server is worse than the difference.
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
 	// Load custom CA bundle if provided
 	if c.CACertificate != "" {


### PR DESCRIPTION
The API client builds a `tls.Config` with no `MinVersion`, so the floor is whatever the Go toolchain happens to default to. That is TLS 1.2 today, and it has moved before — Go raised the client default from 1.0 to 1.2 in 1.18.

Not exploitable as things stand; the point is that the floor is currently inherited rather than chosen, and a toolchain bump could lower it without anything in this repository changing.

**1.2 rather than 1.3, deliberately.** The PowerDNS API is frequently published through an nginx or haproxy front end that has not been moved to 1.3. Silently failing to reach the server is a worse outcome for an operator than the marginal difference between the two versions. If you would rather default to 1.3 and let people opt down, I am happy to change it.

One file, +7/−1. No behaviour change for any endpoint that already negotiates 1.2 or better.

Found by `semgrep --config=p/golang` (`go.lang.security.audit.crypto.missing-ssl-minversion`).

```
go build ./...            ok
go test ./powerdns/       ok
make fmtcheck             clean
golangci-lint run ./...   0 issues
```