### PR TITLE
correct the json tag on ZoneInfo.DNSSec

### DIFF
--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -202,7 +202,7 @@ type ZoneInfo struct {
 	URL                string              `json:"url"`
 	Kind               string              `json:"kind"`
 	Catalog            string              `json:"catalog,omitempty"`
-	DNSSec             bool                `json:"dnsssec"`
+	DNSSec             bool                `json:"dnssec"`
 	Serial             int64               `json:"serial"`
 	Records            []Record            `json:"records,omitempty"`
 	ResourceRecordSets []ResourceRecordSet `json:"rrsets,omitempty"`


### PR DESCRIPTION
The tag reads `dnsssec` — three `s`. PowerDNS sends `dnssec`, so the field never unmarshals and always reads `false`.

```go
DNSSec bool `json:"dnsssec"`   // powerdns/client.go:205
```

**Harmless today**, because nothing in the provider reads the field — which is presumably why the typo survived. It stops being harmless the moment DNSSEC support is added, and it fails silently rather than loudly: a signed zone reports as unsigned.

One character. Fixing it now costs nothing and removes a trap from whoever implements DNSSEC later.

```
go build ./...            ok
go test ./powerdns/       ok
golangci-lint run ./...   0 issues
```