### PR TITLE
correct the resource list in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ provider "powerdns" {
 - `powerdns_record_soa`
 - `powerdns_ptr_record`
 - `powerdns_reverse_zone`
-- `powerdns_view`
+- `powerdns_view_zone_association`
 - `powerdns_network`
+
+### Supported recursor resources
+
+- `powerdns_recursor_config`
+- `powerdns_recursor_forward_zone`
 
 For detailed usage see [provider's documentation page](https://registry.terraform.io/providers/mmianl/powerdns/latest/docs)
 


### PR DESCRIPTION
The README lists `powerdns_view`. That resource does not exist — `provider.go` registers `powerdns_view_zone_association`, and the documentation page is `website/docs/r/view_zone_association.html.markdown`.

A configuration copied from the README fails `terraform validate`.

While there, the list omits the two recursor resources entirely, so they are added under their own heading rather than folded into "authoritative".

Documentation only, no code change.