### PR TITLE
restrict powerdns_recursor_config to the settings the API can write

### DIFF
--- a/powerdns/resource_powerdns_recursor_config.go
+++ b/powerdns/resource_powerdns_recursor_config.go
@@ -11,6 +11,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+// writableRecursorSettings lists the settings the recursor API accepts a write
+// for. Verified against Recursor 5.4.4: ws-recursor.cc registers handlers for
+// /config/allow-from and /config/allow-notify-from only, and any other name
+// returns 404 for both GET and PUT.
+var writableRecursorSettings = []string{
+	"allow-from",
+	"allow-notify-from",
+}
+
 func resourcePDNSRecursorConfig() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourcePDNSRecursorConfigCreate,
@@ -20,11 +29,15 @@ func resourcePDNSRecursorConfig() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-				Description:  "The name of the recursor config setting",
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				// The recursor exposes exactly two settings for writing. Every
+				// other name answers 404 on both GET and PUT, so accepting one
+				// only defers the failure to apply.
+				ValidateFunc: validation.StringInSlice(writableRecursorSettings, false),
+				Description: "The name of the recursor config setting. The recursor API only " +
+					"exposes allow-from and allow-notify-from for writing.",
 			},
 			"value": {
 				Type: schema.TypeSet,


### PR DESCRIPTION
The resource accepts any `name` up to 255 characters. The recursor exposes exactly **two** settings for writing, and every other name answers `404` on both `GET` and `PUT` — so accepting one only defers the failure from plan to apply.

## Evidence

`pdns/recursordist/ws-recursor.cc` at `rec-5.4.4` registers config handlers for these and nothing else:

```
/api/v1/servers/localhost/config/allow-from          GET, PUT
/api/v1/servers/localhost/config/allow-notify-from   GET, PUT
/api/v1/servers/localhost/config                     GET   (whole set, read only)
```

Confirmed against a running 5.4.4:

| setting | GET | PUT |
|---|---|---|
| `allow-from` | 200 | 200 |
| `allow-notify-from` | 200 | 200 |
| `max-cache-entries` | 404 | 404 |
| `loglevel` | 404 | 404 |

`GET /config` does return the whole set — several hundred settings — which is probably why the resource looks more general than it is.

## Compatibility

Strictly speaking this rejects at plan something that was accepted before. But a configuration it now rejects **could not have applied**: it failed at apply with a bare `404`. No working configuration breaks, and the failure becomes legible.

Your own acceptance test uses `allow-from`, so it is unaffected.

```
go build ./...                              ok
go test ./powerdns/ -run TestAccPowerDNSRecursor   ok   (against Recursor 5.4.4)
golangci-lint run ./...                     0 issues
```