### PR TITLE
check the response status in ListZones and ListRecords

### DIFF
--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -357,6 +357,14 @@ func (client *PowerDNSClient) ListZones(ctx context.Context) ([]ZoneInfo, error)
 		}
 	}()
 
+	if resp.StatusCode != http.StatusOK {
+		errorResp := new(errorResponse)
+		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
+			return nil, fmt.Errorf("error listing zones")
+		}
+		return nil, fmt.Errorf("error listing zones, reason: %q", errorResp.ErrorMsg)
+	}
+
 	var zoneInfos []ZoneInfo
 	if err := json.NewDecoder(resp.Body).Decode(&zoneInfos); err != nil {
 		return nil, err
@@ -765,6 +773,14 @@ func (client *PowerDNSClient) ListRecords(ctx context.Context, zone string) ([]R
 				})
 			}
 		}()
+
+		if resp.StatusCode != http.StatusOK {
+			errorResp := new(errorResponse)
+			if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
+				return nil, fmt.Errorf("error listing records for zone: %s", zone)
+			}
+			return nil, fmt.Errorf("error listing records for zone: %s, reason: %q", zone, errorResp.ErrorMsg)
+		}
 
 		zoneInfo = new(ZoneInfo)
 		if err := json.NewDecoder(resp.Body).Decode(zoneInfo); err != nil {

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -774,7 +774,15 @@ func (client *PowerDNSClient) ListRecords(ctx context.Context, zone string) ([]R
 			}
 		}()
 
-		if resp.StatusCode != http.StatusOK {
+		// A missing zone has no records, and callers rely on that: the
+		// CheckDestroy helpers ask for the records of a zone Terraform has
+		// just deleted. Anything other than 404 is a real failure and must not
+		// be decoded into an empty result — a 401 would otherwise read as "the
+		// zone is empty".
+		switch {
+		case resp.StatusCode == http.StatusNotFound:
+			return []Record{}, nil
+		case resp.StatusCode != http.StatusOK:
 			errorResp := new(errorResponse)
 			if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
 				return nil, fmt.Errorf("error listing records for zone: %s", zone)


### PR DESCRIPTION
Both methods decode the response body straight into the success type without examining the status code:

```go
var zoneInfos []ZoneInfo
if err := json.NewDecoder(resp.Body).Decode(&zoneInfos); err != nil {
	return nil, err
}
```

A `401`, `404` or `500` unmarshals into an empty result and is reported as success. In practice an API key with insufficient permissions reads as **an empty zone list** rather than an error — silent, and it points the operator at the wrong thing.

## Scope

I checked the whole client before proposing this rather than assuming it was systemic. It is not:

| | methods |
|---|---:|
| already check the status | 24 |
| did not | 2 |

`ListZones` and `ListRecords` were the only outliers, so this is a two-method fix, not a refactor. The wording follows the idiom already used in `ListZoneMetadata`.

## One deliberate exception

`ListRecords` treats **404 as an empty result**, not an error. Callers depend on it: the `CheckDestroy` helpers ask for the records of a zone Terraform has just deleted. Erroring there broke every record acceptance test — which is how I found it. Anything other than 404 is still a failure, which is the case this change exists for.

```
go build ./...                              ok
go test ./powerdns/ -run "TestAccPDNSRecord|TestAccPDNSZone|TestAccDataSource"   ok
golangci-lint run ./...                     0 issues
```

Verified against PowerDNS Authoritative 5.1.3 on the `gpgsql` backend.