### PR TITLE
fix: explain backend requirements for API failures

### DIFF
--- a/powerdns/backend_hints.go
+++ b/powerdns/backend_hints.go
@@ -11,19 +11,29 @@ import (
 // server's own wording does not point at the fix.
 
 const (
-	viewsBackendHint = "\n\nViews and networks are only implemented by the LMDB backend. " +
-		"The generic SQL backends have no tables for them, so a read returns an empty " +
-		"list while a write fails like this. Check the launch= setting on the server."
+	viewsBackendHint = "\n\nPowerDNS authoritative views and networks require the LMDB backend, " +
+		"views=yes, and a non-zero zone-cache-refresh-interval. Check these settings " +
+		"on the server."
 
 	recursorAPIDirHint = "\n\nThe recursor only accepts writes when api-config-dir is set " +
 		"(webservice.api_dir in the YAML settings). It is unset by default, which makes " +
 		"the whole recursor API read-only."
 )
 
-// viewsHint explains the backend requirement behind a rejected view or network
-// write. Only 422 is annotated: a 404 or 401 means something else entirely.
-func viewsHint(statusCode int) string {
-	if statusCode == http.StatusUnprocessableEntity {
+// viewsHint explains the backend requirement only when PowerDNS reports the
+// failure emitted after a view-capable backend operation returns false. Other
+// 422 responses describe semantic errors and must retain their original meaning.
+func viewsHint(statusCode int, serverMessage string) string {
+	if statusCode != http.StatusUnprocessableEntity {
+		return ""
+	}
+
+	switch {
+	case strings.HasPrefix(serverMessage, "Failed to add ") && strings.Contains(serverMessage, " to view "):
+		return viewsBackendHint
+	case strings.HasPrefix(serverMessage, "Failed to remove ") && strings.Contains(serverMessage, " from view "):
+		return viewsBackendHint
+	case strings.HasPrefix(serverMessage, "Failed to setup view ") && strings.Contains(serverMessage, " for network "):
 		return viewsBackendHint
 	}
 	return ""

--- a/powerdns/backend_hints.go
+++ b/powerdns/backend_hints.go
@@ -1,0 +1,39 @@
+package powerdns
+
+import (
+	"net/http"
+	"strings"
+)
+
+// The PowerDNS API answers an unsupported operation with 422 and a message
+// describing the immediate failure rather than the requirement behind it. Two
+// of those requirements come up often enough to be worth naming, because the
+// server's own wording does not point at the fix.
+
+const (
+	viewsBackendHint = "\n\nViews and networks are only implemented by the LMDB backend. " +
+		"The generic SQL backends have no tables for them, so a read returns an empty " +
+		"list while a write fails like this. Check the launch= setting on the server."
+
+	recursorAPIDirHint = "\n\nThe recursor only accepts writes when api-config-dir is set " +
+		"(webservice.api_dir in the YAML settings). It is unset by default, which makes " +
+		"the whole recursor API read-only."
+)
+
+// viewsHint explains the backend requirement behind a rejected view or network
+// write. Only 422 is annotated: a 404 or 401 means something else entirely.
+func viewsHint(statusCode int) string {
+	if statusCode == http.StatusUnprocessableEntity {
+		return viewsBackendHint
+	}
+	return ""
+}
+
+// recursorHint explains the api-config-dir requirement when the recursor is
+// complaining about it, which it does by name.
+func recursorHint(serverMessage string) string {
+	if strings.Contains(serverMessage, "api-config-dir") {
+		return recursorAPIDirHint
+	}
+	return ""
+}

--- a/powerdns/backend_hints_test.go
+++ b/powerdns/backend_hints_test.go
@@ -7,14 +7,25 @@ import (
 )
 
 func TestViewsHint(t *testing.T) {
-	if hint := viewsHint(http.StatusUnprocessableEntity); !strings.Contains(hint, "LMDB") {
-		t.Errorf("a 422 should mention the LMDB requirement, got: %q", hint)
+	backendFailures := []string{
+		"Failed to add example.com. to view internal",
+		"Failed to remove example.com. from view internal",
+		"Failed to setup view internal for network 192.0.2.0/24",
+	}
+	for _, message := range backendFailures {
+		if hint := viewsHint(http.StatusUnprocessableEntity, message); !strings.Contains(hint, "LMDB") {
+			t.Errorf("a backend failure should mention the LMDB requirement, got: %q", hint)
+		}
 	}
 
 	for _, code := range []int{http.StatusOK, http.StatusNotFound, http.StatusUnauthorized} {
-		if hint := viewsHint(code); hint != "" {
+		if hint := viewsHint(code, backendFailures[0]); hint != "" {
 			t.Errorf("status %d should not be annotated, got: %q", code, hint)
 		}
+	}
+
+	if hint := viewsHint(http.StatusUnprocessableEntity, "Empty view names are not allowed"); hint != "" {
+		t.Errorf("a semantic 422 should not be annotated, got: %q", hint)
 	}
 }
 

--- a/powerdns/backend_hints_test.go
+++ b/powerdns/backend_hints_test.go
@@ -1,0 +1,30 @@
+package powerdns
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestViewsHint(t *testing.T) {
+	if hint := viewsHint(http.StatusUnprocessableEntity); !strings.Contains(hint, "LMDB") {
+		t.Errorf("a 422 should mention the LMDB requirement, got: %q", hint)
+	}
+
+	for _, code := range []int{http.StatusOK, http.StatusNotFound, http.StatusUnauthorized} {
+		if hint := viewsHint(code); hint != "" {
+			t.Errorf("status %d should not be annotated, got: %q", code, hint)
+		}
+	}
+}
+
+func TestRecursorHint(t *testing.T) {
+	message := `Config Option "api-config-dir" must be set`
+	if hint := recursorHint(message); !strings.Contains(hint, "api_dir") {
+		t.Errorf("the api-config-dir message should be explained, got: %q", hint)
+	}
+
+	if hint := recursorHint("Could not find domain 'example.com.'"); hint != "" {
+		t.Errorf("an unrelated message should not be annotated, got: %q", hint)
+	}
+}

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -1105,7 +1105,8 @@ func (client *PowerDNSClient) AddZoneToView(ctx context.Context, viewName, zoneN
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error adding zone %s to view %s: failed to decode error response: %w", zoneName, viewName, err)
 		}
-		return fmt.Errorf("error adding zone %s to view %s: %q", zoneName, viewName, errorResp.ErrorMsg)
+		return fmt.Errorf("error adding zone %s to view %s: %q%s", zoneName, viewName,
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
 	}
 
 	return nil
@@ -1144,7 +1145,8 @@ func (client *PowerDNSClient) RemoveZoneFromView(ctx context.Context, viewName, 
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error removing zone %s from view %s: failed to decode error response: %w", zoneName, viewName, err)
 		}
-		return fmt.Errorf("error removing zone %s from view %s: %q", zoneName, viewName, errorResp.ErrorMsg)
+		return fmt.Errorf("error removing zone %s from view %s: %q%s", zoneName, viewName,
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
 	}
 }
 
@@ -1260,7 +1262,8 @@ func (client *PowerDNSClient) SetNetwork(ctx context.Context, ip, prefixlen, vie
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error setting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
 		}
-		return fmt.Errorf("error setting network %s/%s: %q", ip, prefixlen, errorResp.ErrorMsg)
+		return fmt.Errorf("error setting network %s/%s: %q%s", ip, prefixlen,
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
 	}
 
 	return nil
@@ -1304,7 +1307,8 @@ func (client *PowerDNSClient) DeleteNetwork(ctx context.Context, ip, prefixlen s
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error deleting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
 		}
-		return fmt.Errorf("error deleting network %s/%s: %q", ip, prefixlen, errorResp.ErrorMsg)
+		return fmt.Errorf("error deleting network %s/%s: %q%s", ip, prefixlen,
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
 	}
 }
 
@@ -1426,7 +1430,8 @@ func (client *RecursorClient) CreateForwardZone(ctx context.Context, zone *Recur
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error creating forward zone %s", zone.Name)
 		}
-		return fmt.Errorf("error creating forward zone %s: %q", zone.Name, errorResp.ErrorMsg)
+		return fmt.Errorf("error creating forward zone %s: %q%s", zone.Name,
+			errorResp.ErrorMsg, recursorHint(errorResp.ErrorMsg))
 	}
 
 	return nil
@@ -1468,7 +1473,8 @@ func (client *RecursorClient) DeleteForwardZone(ctx context.Context, name string
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error deleting forward zone %s", name)
 		}
-		return fmt.Errorf("error deleting forward zone %s: %q", name, errorResp.ErrorMsg)
+		return fmt.Errorf("error deleting forward zone %s: %q%s", name,
+			errorResp.ErrorMsg, recursorHint(errorResp.ErrorMsg))
 	}
 }
 
@@ -1555,7 +1561,8 @@ func (client *RecursorClient) SetConfig(ctx context.Context, name string, values
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error setting recursor config %s", name)
 		}
-		return fmt.Errorf("error setting recursor config %s: %q", name, errorResp.ErrorMsg)
+		return fmt.Errorf("error setting recursor config %s: %q%s", name,
+			errorResp.ErrorMsg, recursorHint(errorResp.ErrorMsg))
 	}
 
 	return nil

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -1106,7 +1106,7 @@ func (client *PowerDNSClient) AddZoneToView(ctx context.Context, viewName, zoneN
 			return fmt.Errorf("error adding zone %s to view %s: failed to decode error response: %w", zoneName, viewName, err)
 		}
 		return fmt.Errorf("error adding zone %s to view %s: %q%s", zoneName, viewName,
-			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode, errorResp.ErrorMsg))
 	}
 
 	return nil
@@ -1146,7 +1146,7 @@ func (client *PowerDNSClient) RemoveZoneFromView(ctx context.Context, viewName, 
 			return fmt.Errorf("error removing zone %s from view %s: failed to decode error response: %w", zoneName, viewName, err)
 		}
 		return fmt.Errorf("error removing zone %s from view %s: %q%s", zoneName, viewName,
-			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode, errorResp.ErrorMsg))
 	}
 }
 
@@ -1263,7 +1263,7 @@ func (client *PowerDNSClient) SetNetwork(ctx context.Context, ip, prefixlen, vie
 			return fmt.Errorf("error setting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
 		}
 		return fmt.Errorf("error setting network %s/%s: %q%s", ip, prefixlen,
-			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode, errorResp.ErrorMsg))
 	}
 
 	return nil
@@ -1308,7 +1308,7 @@ func (client *PowerDNSClient) DeleteNetwork(ctx context.Context, ip, prefixlen s
 			return fmt.Errorf("error deleting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
 		}
 		return fmt.Errorf("error deleting network %s/%s: %q%s", ip, prefixlen,
-			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode, errorResp.ErrorMsg))
 	}
 }
 

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -1072,7 +1072,8 @@ func (client *PowerDNSClient) AddZoneToView(ctx context.Context, viewName, zoneN
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error adding zone %s to view %s: failed to decode error response: %w", zoneName, viewName, err)
 		}
-		return fmt.Errorf("error adding zone %s to view %s: %q", zoneName, viewName, errorResp.ErrorMsg)
+		return fmt.Errorf("error adding zone %s to view %s: %q%s", zoneName, viewName,
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
 	}
 
 	return nil
@@ -1111,7 +1112,8 @@ func (client *PowerDNSClient) RemoveZoneFromView(ctx context.Context, viewName, 
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error removing zone %s from view %s: failed to decode error response: %w", zoneName, viewName, err)
 		}
-		return fmt.Errorf("error removing zone %s from view %s: %q", zoneName, viewName, errorResp.ErrorMsg)
+		return fmt.Errorf("error removing zone %s from view %s: %q%s", zoneName, viewName,
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
 	}
 }
 
@@ -1227,7 +1229,8 @@ func (client *PowerDNSClient) SetNetwork(ctx context.Context, ip, prefixlen, vie
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error setting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
 		}
-		return fmt.Errorf("error setting network %s/%s: %q", ip, prefixlen, errorResp.ErrorMsg)
+		return fmt.Errorf("error setting network %s/%s: %q%s", ip, prefixlen,
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
 	}
 
 	return nil
@@ -1271,7 +1274,8 @@ func (client *PowerDNSClient) DeleteNetwork(ctx context.Context, ip, prefixlen s
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error deleting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
 		}
-		return fmt.Errorf("error deleting network %s/%s: %q", ip, prefixlen, errorResp.ErrorMsg)
+		return fmt.Errorf("error deleting network %s/%s: %q%s", ip, prefixlen,
+			errorResp.ErrorMsg, viewsHint(resp.StatusCode))
 	}
 }
 
@@ -1393,7 +1397,8 @@ func (client *RecursorClient) CreateForwardZone(ctx context.Context, zone *Recur
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error creating forward zone %s", zone.Name)
 		}
-		return fmt.Errorf("error creating forward zone %s: %q", zone.Name, errorResp.ErrorMsg)
+		return fmt.Errorf("error creating forward zone %s: %q%s", zone.Name,
+			errorResp.ErrorMsg, recursorHint(errorResp.ErrorMsg))
 	}
 
 	return nil
@@ -1435,7 +1440,8 @@ func (client *RecursorClient) DeleteForwardZone(ctx context.Context, name string
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error deleting forward zone %s", name)
 		}
-		return fmt.Errorf("error deleting forward zone %s: %q", name, errorResp.ErrorMsg)
+		return fmt.Errorf("error deleting forward zone %s: %q%s", name,
+			errorResp.ErrorMsg, recursorHint(errorResp.ErrorMsg))
 	}
 }
 
@@ -1522,7 +1528,8 @@ func (client *RecursorClient) SetConfig(ctx context.Context, name string, values
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("error setting recursor config %s", name)
 		}
-		return fmt.Errorf("error setting recursor config %s: %q", name, errorResp.ErrorMsg)
+		return fmt.Errorf("error setting recursor config %s: %q%s", name,
+			errorResp.ErrorMsg, recursorHint(errorResp.ErrorMsg))
 	}
 
 	return nil

--- a/powerdns/client_views_networks_test.go
+++ b/powerdns/client_views_networks_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,6 +89,43 @@ func TestAddZoneToView(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestAddZoneToViewBackendHint(t *testing.T) {
+	tests := []struct {
+		name          string
+		serverMessage string
+		wantHint      bool
+	}{
+		{
+			name:          "backend failure",
+			serverMessage: "Failed to add example.com. to view test-view",
+			wantHint:      true,
+		},
+		{
+			name:          "semantic failure",
+			serverMessage: "Empty view names are not allowed",
+			wantHint:      false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newTestClient(func(r *http.Request) (*http.Response, error) {
+				return jsonResponse(http.StatusUnprocessableEntity, `{"error":`+strconv.Quote(test.serverMessage)+`}`), nil
+			})
+
+			err := client.AddZoneToView(context.Background(), "test-view", "example.com.")
+			if !assert.Error(t, err) {
+				return
+			}
+			if test.wantHint {
+				assert.ErrorContains(t, err, "LMDB")
+			} else {
+				assert.NotContains(t, err.Error(), "LMDB")
+			}
+		})
+	}
+}
+
 func TestRemoveZoneFromView(t *testing.T) {
 	client := newTestClient(func(r *http.Request) (*http.Response, error) {
 		assert.Equal(t, http.MethodDelete, r.Method)
@@ -156,6 +194,43 @@ func TestSetNetwork(t *testing.T) {
 
 	err := client.SetNetwork(context.Background(), "192.0.2.0", "24", "blue")
 	assert.NoError(t, err)
+}
+
+func TestSetNetworkBackendHint(t *testing.T) {
+	tests := []struct {
+		name          string
+		serverMessage string
+		wantHint      bool
+	}{
+		{
+			name:          "backend failure",
+			serverMessage: "Failed to setup view blue for network 192.0.2.0/24",
+			wantHint:      true,
+		},
+		{
+			name:          "semantic failure",
+			serverMessage: "Invalid network format",
+			wantHint:      false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newTestClient(func(r *http.Request) (*http.Response, error) {
+				return jsonResponse(http.StatusUnprocessableEntity, `{"error":`+strconv.Quote(test.serverMessage)+`}`), nil
+			})
+
+			err := client.SetNetwork(context.Background(), "192.0.2.0", "24", "blue")
+			if !assert.Error(t, err) {
+				return
+			}
+			if test.wantHint {
+				assert.ErrorContains(t, err, "LMDB")
+			} else {
+				assert.NotContains(t, err.Error(), "LMDB")
+			}
+		})
+	}
 }
 
 func TestDeleteNetwork(t *testing.T) {

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -8,6 +8,11 @@ description: |-
 
 # powerdns_network
 
+~> **Backend requirement** Views and networks are only implemented by the LMDB
+backend. On a generic SQL backend a read returns an empty list while a write
+fails with `422`, so this resource cannot be used there. Check the `launch=`
+setting on the server.
+
 Manages one PowerDNS authoritative network-to-view mapping.
 
 PowerDNS networks map client source networks to views. Use this resource together with `powerdns_view` to route clients from a CIDR range to a specific view.

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -8,10 +8,10 @@ description: |-
 
 # powerdns_network
 
-~> **Backend requirement** Views and networks are only implemented by the LMDB
-backend. On a generic SQL backend a read returns an empty list while a write
-fails with `422`, so this resource cannot be used there. Check the `launch=`
-setting on the server.
+~> **Server requirements** PowerDNS authoritative views and networks require
+the LMDB backend, `views=yes`, and a non-zero `zone-cache-refresh-interval`.
+Generic SQL backends do not implement views or networks, so this resource
+cannot be used with them.
 
 Manages one PowerDNS authoritative network-to-view mapping.
 

--- a/website/docs/r/recursor_config.html.markdown
+++ b/website/docs/r/recursor_config.html.markdown
@@ -8,6 +8,11 @@ description: |-
 
 # powerdns_recursor_config
 
+~> **Server requirement** The recursor only accepts writes when
+`api-config-dir` is set (`webservice.api_dir` in the YAML settings). It is
+unset by default, which makes the whole recursor API read-only and causes this
+resource to fail with `422`.
+
 Provides a PowerDNS recursor config resource for managing PowerDNS recursor configuration settings via the recursor API. This resource only supports `incoming.allow_from` and `incoming.allow_notify_from` as per the [PowerDNS Recursor documentation](https://doc.powerdns.com/recursor/http-api/endpoint-servers-config.html).
 
 ## Example Usage

--- a/website/docs/r/recursor_forward_zone.html.markdown
+++ b/website/docs/r/recursor_forward_zone.html.markdown
@@ -8,6 +8,11 @@ description: |-
 
 # powerdns_recursor_forward_zone
 
+~> **Server requirement** The recursor only accepts writes when
+`api-config-dir` is set (`webservice.api_dir` in the YAML settings). It is
+unset by default, which makes the whole recursor API read-only and causes this
+resource to fail with `422`.
+
 Provides a PowerDNS recursor forward zone resource for managing DNS forwarding configuration via the recursor API.
 
 ## Example Usage

--- a/website/docs/r/view_zone_association.html.markdown
+++ b/website/docs/r/view_zone_association.html.markdown
@@ -8,10 +8,10 @@ description: |-
 
 # powerdns_view_zone_association
 
-~> **Backend requirement** Views and networks are only implemented by the LMDB
-backend. On a generic SQL backend a read returns an empty list while a write
-fails with `422`, so this resource cannot be used there. Check the `launch=`
-setting on the server.
+~> **Server requirements** PowerDNS authoritative views and networks require
+the LMDB backend, `views=yes`, and a non-zero `zone-cache-refresh-interval`.
+Generic SQL backends do not implement views or networks, so this resource
+cannot be used with them.
 
 Manages one PowerDNS authoritative view-to-zone association.
 

--- a/website/docs/r/view_zone_association.html.markdown
+++ b/website/docs/r/view_zone_association.html.markdown
@@ -8,6 +8,11 @@ description: |-
 
 # powerdns_view_zone_association
 
+~> **Backend requirement** Views and networks are only implemented by the LMDB
+backend. On a generic SQL backend a read returns an empty list while a write
+fails with `422`, so this resource cannot be used there. Check the `launch=`
+setting on the server.
+
 Manages one PowerDNS authoritative view-to-zone association.
 
 Use this resource together with `powerdns_view` to manage each zone membership independently. This is useful when multiple Terraform resources need to add or remove zones from the same view without replacing the whole view membership set.


### PR DESCRIPTION
## Summary

PowerDNS returns actionable server messages for some failures, but two configuration prerequisites are easy to miss:

- Authoritative views and networks require an LMDB backend with `views=yes` and a non-zero `zone-cache-refresh-interval`.
- Recursor writes require `api-config-dir` (`webservice.api_dir` in YAML).

This change preserves the original server error and appends the relevant requirement.

## Review fix

Authoritative guidance is no longer based on HTTP 422 alone. It is appended only when the response matches one of the backend-operation failure templates emitted by PowerDNS for view/network writes. Other semantic 422 responses remain unchanged.

The resource documentation now lists all three authoritative prerequisites: LMDB, `views=yes`, and an enabled zone cache.

## Source evidence

Verified against PowerDNS Authoritative `auth-5.1.3`:

- `docs/views.rst`: views require LMDB, explicit enablement, and a non-zero zone-cache interval.
- `pdns/ws-auth.cc`: semantic validation errors are emitted before the three backend-operation failure templates.
- `pdns/ueberbackend.cc`: backends without `CAP_VIEWS` are skipped.
- `modules/lmdbbackend/lmdbbackend.cc`: LMDB exposes `CAP_VIEWS` when views are enabled.

## Verification

- `go test -mod=vendor ./powerdns -run 'Test(ViewsHint|AddZoneToViewBackendHint|SetNetworkBackendHint)$' -count=1 -v`
- `go test -mod=vendor ./... -count=1`
- `make test`
- `make fmtcheck`
- `go vet -mod=vendor ./powerdns`
- `golangci-lint run --new-from-rev=origin/main ./...`
- `git diff --check origin/main...HEAD`

All passed locally. The PowerDNS lab acceptance suite was not rerun locally after this rebase; GitHub CI provides the acceptance and e2e gates for the updated head.