### PR TITLE
Deprecate powerdns_record's set_ptr: PowerDNS dropped API support in 4.4.0

### DIFF
--- a/powerdns/resource_powerdns_record.go
+++ b/powerdns/resource_powerdns_record.go
@@ -71,7 +71,8 @@ func resourcePDNSRecord() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "For A and AAAA records, if true, create corresponding PTR.",
+				Deprecated:  "PowerDNS removed API support for automatic PTR record creation in Authoritative Server 4.4.0; setting this has no effect. Manage the PTR record explicitly with the powerdns_ptr_record resource instead.",
+				Description: "Deprecated and non-functional: PowerDNS has not honored this flag since Authoritative Server 4.4.0. Use the powerdns_ptr_record resource instead.",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

`powerdns_record`'s `set_ptr` attribute has been a silent no-op for years PowerDNS removed API support for automatic PTR creation in Authoritative Server 4.4.0 (2020). Setting `set_ptr = true` sends `"set-ptr": true` in the RRset PATCH body, but the server has never acted on it since 4.4.0, so no PTR record is ever created and no error is ever returned.

This PR marks the attribute `Deprecated` so users get a clear warning pointing at `powerdns_ptr_record` (which manages PTR records directly and does work), instead of leaving them under the false impression that PTR records are being managed for them.

## Verification

Confirmed live against real PowerDNS Authoritative Server builds, not just docs:
- `strings` on the `pdns_server` binary shows zero references to `set-ptr`in 4.8.5, 5.1.4 (current stable), and 5.2.0-alpha0.
- Applied a real Terraform config (`set_ptr = true` on an A record, with a matching reverse zone already in place) against a live 5.1.4 container `terraform apply` succeeds cleanly, but the reverse zone never gets a PTR record (checked via both the API and `dig -x`).
- Public issues (tuxis-ie/nsedit#200, hashicorp/terraform#18396) independently confirm this has been broken since 4.4.0.

No behavior changes beyond the new deprecation warning — existing configs using `set_ptr` keep working exactly as before (i.e., still doing nothing), just with a warning now instead of silence.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite, unchanged, all green)
- [x] `terraform validate` against a config using `set_ptr = true` now surfaces the deprecation warning
