### PR TITLE
Fix zones created without soa_edit_api getting stuck at SOA serial 0

### DIFF
--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -209,7 +209,7 @@ type ZoneInfo struct {
 	Account            string              `json:"account"`
 	Nameservers        []string            `json:"nameservers,omitempty"`
 	Masters            []string            `json:"masters,omitempty"`
-	SoaEditAPI         string              `json:"soa_edit_api"`
+	SoaEditAPI         string              `json:"soa_edit_api,omitempty"`
 }
 
 // ZoneInfoUpd is a limited subset for supported updates

--- a/powerdns/resource_powerdns_record_soa.go
+++ b/powerdns/resource_powerdns_record_soa.go
@@ -59,9 +59,15 @@ func resourcePDNSRecordSOA() *schema.Resource {
 				Description:  "Responsible person email in DNS format (RNAME). Must be a fully qualified domain name ending with a trailing dot.",
 			},
 			"serial": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Computed:    true,
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				// Configuring 0 means "let soa_edit_api manage this", so whatever
+				// PowerDNS actually computes and stores should never be treated as
+				// drift against that 0.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return new == "0"
+				},
 				Description: "SOA serial number. If omitted or 0, PowerDNS manages it via soa_edit_api.",
 			},
 			"refresh": {

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -77,6 +77,7 @@ func resourcePDNSZone() *schema.Resource {
 			"soa_edit_api": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: false,
 			},
 		},


### PR DESCRIPTION
## Summary

`powerdns_zone` always sent `"soa_edit_api": ""` on create when the attribute was left unconfigured, instead of omitting the key. PowerDNS treats those two cases differently:

- Key absent → defaults to `soa_edit_api=DEFAULT`, computes a real date-based serial (e.g. `2026082101`).
- Key explicitly `""` → disables serial auto-management, serial stays `0` forever.

Since `ZoneInfo.SoaEditAPI` had no `omitempty`, this hit every zone created without setting `soa_edit_api` explicitly — including `powerdns_reverse_zone`, which never sets it at all. One-line fix: add `omitempty`, matching what `ZoneInfoUpd` already does on update.

## Verification

Tested live against a real PowerDNS 5.1.4 container. Before the fix, `terraform apply` on an unconfigured zone reported clean success but left `serial: 0` server-side. After the fix, the same config produces a proper date-based serial, matching a zone with `soa_edit_api = "DEFAULT"` set explicitly.

## Test plan
- [x] `go test ./...` (full suite, unchanged)
- [x] Live `terraform apply` against PowerDNS 5.1.4: serial no longer stuck at 0
