### PR TITLE
Fix ListViews/ListNetworks decode: API wraps the array in an object

### DIFF
--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -1019,12 +1019,14 @@ func (client *PowerDNSClient) ListViews(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("error listing views: %q", errorResp.ErrorMsg)
 	}
 
-	var views []string
-	if err := json.NewDecoder(resp.Body).Decode(&views); err != nil {
+	var wrapper struct {
+		Views []string `json:"views"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
 		return nil, err
 	}
 
-	return views, nil
+	return wrapper.Views, nil
 }
 
 // GetView retrieves a specific view.
@@ -1179,10 +1181,13 @@ func (client *PowerDNSClient) ListNetworks(ctx context.Context) ([]Network, erro
 		return nil, fmt.Errorf("error listing networks: %q", errorResp.ErrorMsg)
 	}
 
-	var networks []Network
-	if err := json.NewDecoder(resp.Body).Decode(&networks); err != nil {
+	var wrapper struct {
+		Networks []Network `json:"networks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
 		return nil, err
 	}
+	networks := wrapper.Networks
 
 	return networks, nil
 }

--- a/powerdns/client_metadata_test.go
+++ b/powerdns/client_metadata_test.go
@@ -51,7 +51,7 @@ func TestAuthoritativeServerIDRoutes(t *testing.T) {
 		jsonResponse(http.StatusOK, `[]`),
 		jsonResponse(http.StatusNoContent, ``),
 		jsonResponse(http.StatusOK, `{"zones":[]}`),
-		jsonResponse(http.StatusOK, `[]`),
+		jsonResponse(http.StatusOK, `{"networks":[]}`),
 	}
 	requestIndex := 0
 	client := newTestClient(func(r *http.Request) (*http.Response, error) {

--- a/powerdns/client_views_networks_test.go
+++ b/powerdns/client_views_networks_test.go
@@ -158,7 +158,8 @@ func TestListNetworks(t *testing.T) {
 	client := newTestClient(func(r *http.Request) (*http.Response, error) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/v1/servers/localhost/networks", r.URL.Path)
-		return jsonResponse(http.StatusOK, `[{"network":"192.0.2.0/24","view":"blue"},{"network":"2001:db8::/32","view":"green"}]`), nil
+		// PowerDNS wraps the list in a "networks" object, not a bare array.
+		return jsonResponse(http.StatusOK, `{"networks":[{"network":"192.0.2.0/24","view":"blue"},{"network":"2001:db8::/32","view":"green"}]}`), nil
 	})
 
 	networks, err := client.ListNetworks(context.Background())
@@ -169,6 +170,21 @@ func TestListNetworks(t *testing.T) {
 		{Network: "192.0.2.0/24", View: "blue"},
 		{Network: "2001:db8::/32", View: "green"},
 	}, networks)
+}
+
+func TestListViews(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/servers/localhost/views", r.URL.Path)
+		// PowerDNS wraps the list in a "views" object, not a bare array.
+		return jsonResponse(http.StatusOK, `{"views":["blue","green"]}`), nil
+	})
+
+	views, err := client.ListViews(context.Background())
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, []string{"blue", "green"}, views)
 }
 
 func TestSetNetwork(t *testing.T) {


### PR DESCRIPTION
## Summary

`ListViews` and `ListNetworks` decoded the response body straight into a bare `[]string`/`[]Network`, but PowerDNS wraps both lists in an object: `GET /servers/{id}/views` returns `{"views": [...]}` and `GET /servers/{id}/networks` returns `{"networks": [...]}`. Decoding an object into a bare slice fails outright.

Neither method is called by any resource/data source today, so nothing user-facing breaks currently — but the matching unit tests mocked the wrong (bare-array) shape, so they passed despite the bug. Any future "list views/networks" data source built on these would have failed immediately.

## Fix

Decode into a small wrapper struct for each, matching the real response shape. Also corrected the existing test mocks and added a `ListViews` test (there wasn't one before).

## Verification

Created a real view and network via `terraform apply`, then called `ListViews`/`ListNetworks` directly against that live PowerDNS 5.1.4 server. Before the fix: `json: cannot unmarshal object into Go value of type []string` (and `[]powerdns.Network`). After the fix: both decode correctly and return the actual data.

## Test plan
- [x] `go test ./...` (full suite green)
- [x] Live call against a real server with actual view/network data: clean decode, no errors
