### PR TITLE
Correct GetView test mocks to match the real API response shape

### DIFF
--- a/powerdns/client_metadata_test.go
+++ b/powerdns/client_metadata_test.go
@@ -50,7 +50,7 @@ func TestAuthoritativeServerIDRoutes(t *testing.T) {
 		jsonResponse(http.StatusOK, `[]`),
 		jsonResponse(http.StatusOK, `[]`),
 		jsonResponse(http.StatusNoContent, ``),
-		jsonResponse(http.StatusOK, `{"id":"test-view","name":"test-view","zones":[]}`),
+		jsonResponse(http.StatusOK, `{"zones":[]}`),
 		jsonResponse(http.StatusOK, `[]`),
 	}
 	requestIndex := 0

--- a/powerdns/client_views_networks_test.go
+++ b/powerdns/client_views_networks_test.go
@@ -16,7 +16,9 @@ func TestGetView(t *testing.T) {
 	client := newTestClient(func(r *http.Request) (*http.Response, error) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/v1/servers/localhost/views/test-view", r.URL.Path)
-		return jsonResponse(http.StatusOK, `{"id":"test-view","name":"test-view","zones":[]}`), nil
+		// The real API returns only {"zones": [...]} - no "id"/"name" key at
+		// all. GetView must fall back to the requested view name itself.
+		return jsonResponse(http.StatusOK, `{"zones":[]}`), nil
 	})
 
 	view, err := client.GetView(context.Background(), "test-view")
@@ -31,7 +33,7 @@ func TestGetViewWithZoneAssociations(t *testing.T) {
 	client := newTestClient(func(r *http.Request) (*http.Response, error) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/v1/servers/localhost/views/test-view", r.URL.Path)
-		return jsonResponse(http.StatusOK, `{"id":"test-view","name":"test-view","zones":["example.com.","example.com..internal"]}`), nil
+		return jsonResponse(http.StatusOK, `{"zones":["example.com.","example.com..internal"]}`), nil
 	})
 
 	view, err := client.GetView(context.Background(), "test-view")


### PR DESCRIPTION
## Summary

`GetView`'s unit test mocks returned `{"id":"test-view","name":"test-view","zones":[...]}`, but the real `GET /servers/{id}/views/{view}` endpoint returns only `{"zones": [...]}` — no `id` or `name` key at all. The tests happened to pass anyway because `GetView` already falls back to the requested view name when the decoded `Name` comes back empty, so this isn't a production bug — just a test that didn't reflect reality and could have hidden a real regression in that fallback.

## Fix

Updated the mocked responses (in both `client_views_networks_test.go` and the shared route test in `client_metadata_test.go`) to the real shape. No production code changes.

## Verification

Confirmed the real response shape live against a PowerDNS 5.1.4/5.2.0-alpha0 server by dumping the raw body before `GetView`'s own decoding/fallback logic runs.

## Test plan
- [x] `go test ./...` (full suite green)
