### PR TITLE
Fix silently-dropped log fields, request cancellation, and stale cache reads; consolidate API client

### DIFF
--- a/powerdns/backend_hints.go
+++ b/powerdns/backend_hints.go
@@ -47,3 +47,9 @@ func recursorHint(serverMessage string) string {
 	}
 	return ""
 }
+
+// recursorMessageHint adapts recursorHint to the hint signature used by
+// requestOptions; the recursor names the missing setting regardless of status.
+func recursorMessageHint(_ int, serverMessage string) string {
+	return recursorHint(serverMessage)
+}

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -1,17 +1,16 @@
 package powerdns
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 
 	freecache "github.com/coocood/freecache"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
@@ -21,9 +20,6 @@ import (
 // DefaultSchema is the value used for the URL in case
 // no schema is explicitly defined
 var DefaultSchema = "https"
-
-// DefaultCacheSize is client default cache size
-var DefaultCacheSize int
 
 // sanitizeURL will output:
 // <scheme>://<host>[:port]
@@ -75,11 +71,17 @@ func sanitizeURL(URL string) (string, error) {
 type BaseClient struct {
 	ServerURL   string // Location of the server to use
 	APIKey      string // REST API Static authentication key
-	APIVersion  int    // API version to use
+	APIVersion  int    // API version to use; -1 until detected
 	HTTP        *http.Client
 	CacheEnable bool // Enable/Disable cache for REST API requests
 	Cache       *freecache.Cache
+	CacheSize   int
 	CacheTTL    int
+
+	// A single client is shared by every resource, and Terraform walks the
+	// graph in parallel, so version detection must happen exactly once.
+	apiVersionOnce sync.Once
+	apiVersionErr  error
 }
 
 // NewBaseClient constructs a BaseClient with HTTP, TLS and cache configuration.
@@ -92,106 +94,27 @@ func NewBaseClient(serverURL string, apiKey string, configTLS *tls.Config, cache
 	httpClient := cleanhttp.DefaultClient()
 	httpClient.Transport.(*http.Transport).TLSClientConfig = configTLS
 
+	base := &BaseClient{
+		ServerURL: cleanURL,
+		APIKey:    apiKey,
+		HTTP:      httpClient,
+		// -1 marks the version as not yet detected; see BaseClient.apiVersion.
+		APIVersion:  -1,
+		CacheEnable: cacheEnable,
+		CacheTTL:    cacheTTL,
+	}
+
+	// Only allocate the cache when it will actually be read.
 	if cacheEnable {
 		cacheSize, err := strconv.Atoi(cacheSizeMB)
 		if err != nil {
 			return nil, fmt.Errorf("error while creating client: %s", err)
 		}
-		DefaultCacheSize = cacheSize * 1024 * 1024
-	}
-
-	base := &BaseClient{
-		ServerURL:   cleanURL,
-		APIKey:      apiKey,
-		HTTP:        httpClient,
-		APIVersion:  -1,
-		CacheEnable: cacheEnable,
-		Cache:       freecache.NewCache(DefaultCacheSize),
-		CacheTTL:    cacheTTL,
+		base.CacheSize = cacheSize * 1024 * 1024
+		base.Cache = freecache.NewCache(base.CacheSize)
 	}
 
 	return base, nil
-}
-
-// newRequest creates a new request against the API with necessary headers.
-func (client *BaseClient) newRequest(ctx context.Context, method string, endpoint string, body []byte) (*http.Request, error) {
-	var err error
-	if client.APIVersion < 0 {
-		client.APIVersion, err = client.detectAPIVersion(ctx)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	var urlStr string
-	if client.APIVersion > 0 {
-		urlStr = client.ServerURL + "/api/v" + strconv.Itoa(client.APIVersion) + endpoint
-	} else {
-		urlStr = client.ServerURL + endpoint
-	}
-	u, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, fmt.Errorf("error during parsing request URL: %s", err)
-	}
-
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, u.String(), bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("error during creation of request: %s", err)
-	}
-
-	req.Header.Add("X-API-Key", client.APIKey)
-	req.Header.Add("Accept", "application/json")
-
-	if method != http.MethodGet {
-		req.Header.Add("Content-Type", "application/json")
-	}
-
-	return req, nil
-}
-
-// Detects the API version in use on the server
-// Uses int to represent the API version: 0 is the legacy AKA version 3.4 API
-// Any other integer correlates with the same API version
-func (client *BaseClient) detectAPIVersion(ctx context.Context) (int, error) {
-	httpClient := client.HTTP
-
-	u, err := url.Parse(client.ServerURL + "/api/v1/servers")
-	if err != nil {
-		return -1, fmt.Errorf("error while trying to detect the API version, request URL: %s", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return -1, fmt.Errorf("error during creation of request: %s", err)
-	}
-
-	req.Header.Add("X-API-Key", client.APIKey)
-	req.Header.Add("Accept", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return -1, err
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-			})
-		}
-	}()
-
-	if resp.StatusCode == http.StatusOK {
-		return 1, nil
-	}
-	return 0, nil
 }
 
 // PowerDNSClient is the concrete client used by the provider.
@@ -342,40 +265,38 @@ func NewPowerDNSClient(ctx context.Context, serverURL string, serverID string, a
 
 // serverEndpoint returns an API path scoped to the configured authoritative server.
 func (client *PowerDNSClient) serverEndpoint(path string) string {
-	return "/servers/" + url.PathEscape(client.serverID) + path
+	return "/servers/" + pathEscape(client.serverID) + path
+}
+
+// zoneEndpoint returns the API path for a single zone.
+func (client *PowerDNSClient) zoneEndpoint(zone string) string {
+	return client.serverEndpoint("/zones/" + pathEscape(zone))
+}
+
+// zoneMetadataEndpoint returns the API path for one metadata kind of a zone.
+func (client *PowerDNSClient) zoneMetadataEndpoint(zone, kind string) string {
+	return client.zoneEndpoint(zone) + "/metadata/" + pathEscape(kind)
+}
+
+// viewEndpoint returns the API path for a single view.
+func (client *PowerDNSClient) viewEndpoint(view string) string {
+	return client.serverEndpoint("/views/" + pathEscape(view))
+}
+
+// networkEndpoint returns the API path for a single network.
+func (client *PowerDNSClient) networkEndpoint(ip, prefixlen string) string {
+	return client.serverEndpoint("/networks/" + pathEscape(ip) + "/" + pathEscape(prefixlen))
 }
 
 // ListZones returns all Zones of server, without records
 func (client *PowerDNSClient) ListZones(ctx context.Context) ([]ZoneInfo, error) {
-	req, err := client.newRequest(ctx, http.MethodGet, client.serverEndpoint("/zones"), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return nil, fmt.Errorf("error listing zones")
-		}
-		return nil, fmt.Errorf("error listing zones, reason: %q", errorResp.ErrorMsg)
-	}
-
 	var zoneInfos []ZoneInfo
-	if err := json.NewDecoder(resp.Body).Decode(&zoneInfos); err != nil {
+	_, err := client.do(ctx, requestOptions{
+		endpoint: client.serverEndpoint("/zones"),
+		out:      &zoneInfos,
+		describe: "listing zones",
+	})
+	if err != nil {
 		return nil, err
 	}
 
@@ -393,41 +314,19 @@ func (client *PowerDNSClient) GetZoneWithRRsets(ctx context.Context, name string
 }
 
 func (client *PowerDNSClient) getZone(ctx context.Context, name string, includeRRsets bool) (ZoneInfo, error) {
-	endpoint := client.serverEndpoint(fmt.Sprintf("/zones/%s", name))
+	endpoint := client.zoneEndpoint(name)
 	if includeRRsets {
 		endpoint += "?rrsets=true"
 	}
 
-	req, err := client.newRequest(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return ZoneInfo{}, err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return ZoneInfo{}, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   name,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return ZoneInfo{}, fmt.Errorf("error getting zone: %s", name)
-		}
-		return ZoneInfo{}, fmt.Errorf("error getting zone: %s, reason: %q", name, errorResp.ErrorMsg)
-	}
-
 	var zoneInfo ZoneInfo
-	if err := json.NewDecoder(resp.Body).Decode(&zoneInfo); err != nil {
+	_, err := client.do(ctx, requestOptions{
+		endpoint:  endpoint,
+		out:       &zoneInfo,
+		describe:  fmt.Sprintf("getting zone: %s", name),
+		logFields: map[string]any{"zone": name},
+	})
+	if err != nil {
 		return ZoneInfo{}, err
 	}
 
@@ -436,74 +335,32 @@ func (client *PowerDNSClient) getZone(ctx context.Context, name string, includeR
 
 // ZoneExists checks if requested zone exists
 func (client *PowerDNSClient) ZoneExists(ctx context.Context, name string) (bool, error) {
-	req, err := client.newRequest(ctx, http.MethodGet, client.serverEndpoint(fmt.Sprintf("/zones/%s", name)), nil)
+	statusCode, err := client.do(ctx, requestOptions{
+		endpoint:  client.zoneEndpoint(name),
+		okCodes:   []int{http.StatusOK, http.StatusNotFound},
+		describe:  fmt.Sprintf("getting zone: %s", name),
+		logFields: map[string]any{"zone": name},
+	})
 	if err != nil {
 		return false, err
 	}
 
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return false, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   name,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return false, fmt.Errorf("error getting zone: %s", name)
-		}
-		return false, fmt.Errorf("error getting zone: %s, reason: %q", name, errorResp.ErrorMsg)
-	}
-
-	return resp.StatusCode == http.StatusOK, nil
+	return statusCode == http.StatusOK, nil
 }
 
 // CreateZone creates a zone
 func (client *PowerDNSClient) CreateZone(ctx context.Context, zoneInfo ZoneInfo) (ZoneInfo, error) {
-	body, err := json.Marshal(zoneInfo)
-	if err != nil {
-		return ZoneInfo{}, err
-	}
-
-	req, err := client.newRequest(ctx, http.MethodPost, client.serverEndpoint("/zones"), body)
-	if err != nil {
-		return ZoneInfo{}, err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return ZoneInfo{}, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   zoneInfo.Name,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusCreated {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return ZoneInfo{}, fmt.Errorf("error creating zone: %s", zoneInfo.Name)
-		}
-		return ZoneInfo{}, fmt.Errorf("error creating zone: %s, reason: %q", zoneInfo.Name, errorResp.ErrorMsg)
-	}
-
 	var createdZoneInfo ZoneInfo
-	if err := json.NewDecoder(resp.Body).Decode(&createdZoneInfo); err != nil {
+	_, err := client.do(ctx, requestOptions{
+		method:    http.MethodPost,
+		endpoint:  client.serverEndpoint("/zones"),
+		body:      zoneInfo,
+		out:       &createdZoneInfo,
+		okCodes:   []int{http.StatusCreated},
+		describe:  fmt.Sprintf("creating zone: %s", zoneInfo.Name),
+		logFields: map[string]any{"zone": zoneInfo.Name},
+	})
+	if err != nil {
 		return ZoneInfo{}, err
 	}
 
@@ -512,106 +369,49 @@ func (client *PowerDNSClient) CreateZone(ctx context.Context, zoneInfo ZoneInfo)
 
 // UpdateZone updates a zone
 func (client *PowerDNSClient) UpdateZone(ctx context.Context, name string, zoneInfo ZoneInfoUpd) error {
-	body, err := json.Marshal(zoneInfo)
+	_, err := client.do(ctx, requestOptions{
+		method:    http.MethodPut,
+		endpoint:  client.zoneEndpoint(name),
+		body:      zoneInfo,
+		okCodes:   []int{http.StatusNoContent},
+		describe:  fmt.Sprintf("updating zone: %s", name),
+		logFields: map[string]any{"zone": name},
+	})
 	if err != nil {
 		return err
 	}
 
-	req, err := client.newRequest(ctx, http.MethodPut, client.serverEndpoint(fmt.Sprintf("/zones/%s", name)), body)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   name,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusNoContent {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return fmt.Errorf("error updating zone: %s", zoneInfo.Name)
-		}
-		return fmt.Errorf("error updating zone: %s, reason: %q", zoneInfo.Name, errorResp.ErrorMsg)
-	}
-
+	client.invalidateZoneCache(ctx, name)
 	return nil
 }
 
 // DeleteZone deletes a zone
 func (client *PowerDNSClient) DeleteZone(ctx context.Context, name string) error {
-	req, err := client.newRequest(ctx, http.MethodDelete, client.serverEndpoint(fmt.Sprintf("/zones/%s", name)), nil)
+	_, err := client.do(ctx, requestOptions{
+		method:    http.MethodDelete,
+		endpoint:  client.zoneEndpoint(name),
+		okCodes:   []int{http.StatusNoContent},
+		describe:  fmt.Sprintf("deleting zone: %s", name),
+		logFields: map[string]any{"zone": name},
+	})
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   name,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusNoContent {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return fmt.Errorf("error deleting zone: %s", name)
-		}
-		return fmt.Errorf("error deleting zone: %s, reason: %q", name, errorResp.ErrorMsg)
-	}
+	client.invalidateZoneCache(ctx, name)
 	return nil
 }
 
 // ListZoneMetadata returns all domain metadata entries for a zone.
 func (client *PowerDNSClient) ListZoneMetadata(ctx context.Context, zone string) ([]ZoneMetadata, error) {
-	req, err := client.newRequest(ctx, http.MethodGet, client.serverEndpoint(fmt.Sprintf("/zones/%s/metadata", zone)), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   zone,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return nil, fmt.Errorf("error reading zone metadata: %s", zone)
-		}
-		return nil, fmt.Errorf("error reading zone metadata: %s, reason: %q", zone, errorResp.ErrorMsg)
-	}
-
 	var metadata []ZoneMetadata
-	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
+	_, err := client.do(ctx, requestOptions{
+		endpoint:  client.zoneEndpoint(zone) + "/metadata",
+		out:       &metadata,
+		describe:  fmt.Sprintf("reading zone metadata: %s", zone),
+		logFields: map[string]any{"zone": zone},
+	})
+	if err != nil {
 		return nil, err
 	}
 
@@ -620,37 +420,14 @@ func (client *PowerDNSClient) ListZoneMetadata(ctx context.Context, zone string)
 
 // GetZoneMetadata returns one metadata kind for a zone.
 func (client *PowerDNSClient) GetZoneMetadata(ctx context.Context, zone string, kind string) (ZoneMetadata, error) {
-	req, err := client.newRequest(ctx, http.MethodGet, client.serverEndpoint(fmt.Sprintf("/zones/%s/metadata/%s", zone, kind)), nil)
-	if err != nil {
-		return ZoneMetadata{}, err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return ZoneMetadata{}, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   zone,
-				"kind":   kind,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return ZoneMetadata{}, fmt.Errorf("error reading zone metadata: %s (%s)", zone, kind)
-		}
-		return ZoneMetadata{}, fmt.Errorf("error reading zone metadata: %s (%s), reason: %q", zone, kind, errorResp.ErrorMsg)
-	}
-
 	var metadata ZoneMetadata
-	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
+	_, err := client.do(ctx, requestOptions{
+		endpoint:  client.zoneMetadataEndpoint(zone, kind),
+		out:       &metadata,
+		describe:  fmt.Sprintf("reading zone metadata: %s (%s)", zone, kind),
+		logFields: map[string]any{"zone": zone, "kind": kind},
+	})
+	if err != nil {
 		return ZoneMetadata{}, err
 	}
 
@@ -659,168 +436,118 @@ func (client *PowerDNSClient) GetZoneMetadata(ctx context.Context, zone string, 
 
 // ReplaceZoneMetadata replaces all values for a metadata kind in a zone.
 func (client *PowerDNSClient) ReplaceZoneMetadata(ctx context.Context, zone string, kind string, values []string) error {
-	body, err := json.Marshal(ZoneMetadata{
-		Kind:     kind,
-		Metadata: values,
+	_, err := client.do(ctx, requestOptions{
+		method:   http.MethodPut,
+		endpoint: client.zoneMetadataEndpoint(zone, kind),
+		body: ZoneMetadata{
+			Kind:     kind,
+			Metadata: values,
+		},
+		okCodes:   []int{http.StatusOK, http.StatusNoContent},
+		describe:  fmt.Sprintf("replacing zone metadata: %s (%s)", zone, kind),
+		logFields: map[string]any{"zone": zone, "kind": kind},
 	})
-	if err != nil {
-		return err
-	}
-	req, err := client.newRequest(ctx, http.MethodPut, client.serverEndpoint(fmt.Sprintf("/zones/%s/metadata/%s", zone, kind)), body)
-	if err != nil {
-		return err
-	}
 
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   zone,
-				"kind":   kind,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return fmt.Errorf("error replacing zone metadata: %s (%s)", zone, kind)
-		}
-		return fmt.Errorf("error replacing zone metadata: %s (%s), reason: %q", zone, kind, errorResp.ErrorMsg)
-	}
-
-	return nil
+	return err
 }
 
 // DeleteZoneMetadata deletes all values for a metadata kind in a zone.
 func (client *PowerDNSClient) DeleteZoneMetadata(ctx context.Context, zone string, kind string) error {
-	req, err := client.newRequest(ctx, http.MethodDelete, client.serverEndpoint(fmt.Sprintf("/zones/%s/metadata/%s", zone, kind)), nil)
-	if err != nil {
-		return err
-	}
+	_, err := client.do(ctx, requestOptions{
+		method:    http.MethodDelete,
+		endpoint:  client.zoneMetadataEndpoint(zone, kind),
+		okCodes:   []int{http.StatusNoContent},
+		describe:  fmt.Sprintf("deleting zone metadata: %s (%s)", zone, kind),
+		logFields: map[string]any{"zone": zone, "kind": kind},
+	})
 
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   zone,
-				"kind":   kind,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusNoContent {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return fmt.Errorf("error deleting zone metadata: %s (%s)", zone, kind)
-		}
-		return fmt.Errorf("error deleting zone metadata: %s (%s), reason: %q", zone, kind, errorResp.ErrorMsg)
-	}
-
-	return nil
+	return err
 }
 
-// GetZoneInfoFromCache return ZoneInfo struct
-func (client *PowerDNSClient) GetZoneInfoFromCache(ctx context.Context, zone string) (*ZoneInfo, error) {
-	if client.CacheEnable {
-		cacheZoneInfo, err := client.Cache.Get([]byte(zone))
-		if err != nil {
-			return nil, err
-		}
-
-		zoneInfo := new(ZoneInfo)
-		if err := json.Unmarshal(cacheZoneInfo, &zoneInfo); err != nil {
-			return nil, err
-		}
-
-		return zoneInfo, nil
+// getCachedZoneInfo returns the cached ZoneInfo for a zone. found is false when
+// caching is disabled or the zone is simply not cached yet; only a malformed
+// cache entry is reported as an error.
+func (client *PowerDNSClient) getCachedZoneInfo(ctx context.Context, zone string) (info *ZoneInfo, found bool, err error) {
+	if !client.CacheEnable || client.Cache == nil {
+		return nil, false, nil
 	}
 
-	return nil, nil
+	cached, err := client.Cache.Get([]byte(zone))
+	if err != nil {
+		// freecache reports an ordinary miss as an error; that is not a failure.
+		return nil, false, nil
+	}
+
+	zoneInfo := new(ZoneInfo)
+	if err := json.Unmarshal(cached, zoneInfo); err != nil {
+		tflog.Warn(ctx, "Discarding malformed zone cache entry", map[string]any{
+			"zone":  zone,
+			"error": err.Error(),
+		})
+		client.Cache.Del([]byte(zone))
+		return nil, false, nil
+	}
+
+	return zoneInfo, true, nil
+}
+
+// invalidateZoneCache drops a zone's cached records. Every write path calls
+// this: without it a read issued later in the same apply can still be served
+// the pre-write zone and be recorded as drift.
+func (client *PowerDNSClient) invalidateZoneCache(ctx context.Context, zone string) {
+	if !client.CacheEnable || client.Cache == nil {
+		return
+	}
+
+	if client.Cache.Del([]byte(zone)) {
+		tflog.Debug(ctx, "Invalidated zone cache", map[string]any{"zone": zone})
+	}
 }
 
 // ListRecords returns all records in Zone
 func (client *PowerDNSClient) ListRecords(ctx context.Context, zone string) ([]Record, error) {
-	zoneInfo, err := client.GetZoneInfoFromCache(ctx, zone)
+	zoneInfo, found, err := client.getCachedZoneInfo(ctx, zone)
 	if err != nil {
-		tflog.Warn(ctx, "Cache get failed", map[string]interface{}{
-			"zone":  zone,
-			"error": err.Error(),
-		})
 		return nil, err
 	}
 
-	if zoneInfo == nil {
-		req, err := client.newRequest(ctx, http.MethodGet, client.serverEndpoint(fmt.Sprintf("/zones/%s?rrsets=true", zone)), nil)
-		if err != nil {
-			return nil, err
-		}
-
-		resp, err := client.HTTP.Do(req)
-		if err != nil {
-			return nil, err
-		}
-		defer func() {
-			if err := resp.Body.Close(); err != nil {
-				tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-					"error":  err.Error(),
-					"method": req.Method,
-					"url":    req.URL.String(),
-					"zone":   zone,
-				})
-			}
-		}()
-
+	if !found {
+		zoneInfo = new(ZoneInfo)
 		// A missing zone has no records, and callers rely on that: the
 		// CheckDestroy helpers ask for the records of a zone Terraform has
 		// just deleted. Anything other than 404 is a real failure and must not
-		// be decoded into an empty result — a 401 would otherwise read as "the
+		// be decoded into an empty result - a 401 would otherwise read as "the
 		// zone is empty".
-		switch {
-		case resp.StatusCode == http.StatusNotFound:
-			return []Record{}, nil
-		case resp.StatusCode != http.StatusOK:
-			errorResp := new(errorResponse)
-			if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-				return nil, fmt.Errorf("error listing records for zone: %s", zone)
-			}
-			return nil, fmt.Errorf("error listing records for zone: %s, reason: %q", zone, errorResp.ErrorMsg)
-		}
-
-		zoneInfo = new(ZoneInfo)
-		if err := json.NewDecoder(resp.Body).Decode(zoneInfo); err != nil {
+		statusCode, err := client.do(ctx, requestOptions{
+			endpoint:  client.zoneEndpoint(zone) + "?rrsets=true",
+			out:       zoneInfo,
+			okCodes:   []int{http.StatusOK, http.StatusNotFound},
+			describe:  fmt.Sprintf("listing records for zone: %s", zone),
+			logFields: map[string]any{"zone": zone},
+		})
+		if err != nil {
 			return nil, err
 		}
+		if statusCode == http.StatusNotFound {
+			return []Record{}, nil
+		}
 
-		if client.CacheEnable {
+		if client.CacheEnable && client.Cache != nil {
 			cacheValue, err := json.Marshal(zoneInfo)
 			if err != nil {
 				return nil, err
 			}
 
 			if err := client.Cache.Set([]byte(zone), cacheValue, client.CacheTTL); err != nil {
-				return nil, fmt.Errorf("the cache for REST API requests is enabled but the size isn't enough: cacheSize: %db \n %s",
-					DefaultCacheSize, err)
+				return nil, fmt.Errorf("the cache for REST API requests is enabled but the size isn't enough: cacheSize: %db: %w", client.CacheSize, err)
 			}
 		}
 	}
 
 	records := zoneInfo.Records
 	// Convert the API v1 response to v0 record structure
-	for _, rrs := range zoneInfo.ResourceRecordSets {
-		records = append(records, recordsFromRRSet(&rrs)...)
+	for i := range zoneInfo.ResourceRecordSets {
+		records = append(records, recordsFromRRSet(&zoneInfo.ResourceRecordSets[i])...)
 	}
 
 	return records, nil
@@ -833,7 +560,7 @@ func (client *PowerDNSClient) ListRecordsInRRSet(ctx context.Context, zone strin
 		return nil, err
 	}
 
-	records := make([]Record, 0, 10)
+	records := make([]Record, 0, len(allRecords))
 	for _, r := range allRecords {
 		if strings.EqualFold(r.Name, name) && strings.EqualFold(r.Type, tpe) {
 			records = append(records, r)
@@ -864,10 +591,10 @@ func (client *PowerDNSClient) GetRecordSetByID(ctx context.Context, zone string,
 		return nil, err
 	}
 
-	for _, rrSet := range zoneInfo.ResourceRecordSets {
+	for i := range zoneInfo.ResourceRecordSets {
+		rrSet := &zoneInfo.ResourceRecordSets[i]
 		if strings.EqualFold(rrSet.Name, name) && strings.EqualFold(rrSet.Type, tpe) {
-			found := rrSet
-			return &found, nil
+			return rrSet, nil
 		}
 	}
 
@@ -902,88 +629,47 @@ func (client *PowerDNSClient) RecordExistsByID(ctx context.Context, zone string,
 func (client *PowerDNSClient) ReplaceRecordSet(ctx context.Context, zone string, rrSet ResourceRecordSet) (string, error) {
 	rrSet.ChangeType = "REPLACE"
 
-	reqBody, err := json.Marshal(zonePatchRequest{
-		RecordSets: []ResourceRecordSet{rrSet},
+	_, err := client.do(ctx, requestOptions{
+		method:   http.MethodPatch,
+		endpoint: client.zoneEndpoint(zone),
+		body: zonePatchRequest{
+			RecordSets: []ResourceRecordSet{rrSet},
+		},
+		okCodes:   []int{http.StatusOK, http.StatusNoContent},
+		describe:  fmt.Sprintf("creating record set: %s", rrSet.ID()),
+		logFields: map[string]any{"zone": zone, "rrsetId": rrSet.ID()},
 	})
 	if err != nil {
 		return "", err
 	}
 
-	req, err := client.newRequest(ctx, http.MethodPatch, client.serverEndpoint(fmt.Sprintf("/zones/%s", zone)), reqBody)
-	if err != nil {
-		return "", err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":   err.Error(),
-				"method":  req.Method,
-				"url":     req.URL.String(),
-				"zone":    zone,
-				"rrsetId": rrSet.ID(),
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return "", fmt.Errorf("error creating record set: %s", rrSet.ID())
-		}
-		return "", fmt.Errorf("error creating record set: %s, reason: %q", rrSet.ID(), errorResp.ErrorMsg)
-	}
+	client.invalidateZoneCache(ctx, zone)
 	return rrSet.ID(), nil
 }
 
 // DeleteRecordSet deletes record set from Zone
 func (client *PowerDNSClient) DeleteRecordSet(ctx context.Context, zone string, name string, tpe string) error {
-	reqBody, err := json.Marshal(zonePatchRequest{
-		RecordSets: []ResourceRecordSet{
-			{
-				Name:       name,
-				Type:       tpe,
-				ChangeType: "DELETE",
+	_, err := client.do(ctx, requestOptions{
+		method:   http.MethodPatch,
+		endpoint: client.zoneEndpoint(zone),
+		body: zonePatchRequest{
+			RecordSets: []ResourceRecordSet{
+				{
+					Name:       name,
+					Type:       tpe,
+					ChangeType: "DELETE",
+				},
 			},
 		},
+		okCodes:   []int{http.StatusOK, http.StatusNoContent},
+		describe:  fmt.Sprintf("deleting record: %s %s", name, tpe),
+		logFields: map[string]any{"zone": zone, "name": name, "type": tpe},
 	})
 	if err != nil {
 		return err
 	}
 
-	req, err := client.newRequest(ctx, http.MethodPatch, client.serverEndpoint(fmt.Sprintf("/zones/%s", zone)), reqBody)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   zone,
-				"name":   name,
-				"type":   tpe,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		errorResp := new(errorResponse)
-		if err = json.NewDecoder(resp.Body).Decode(errorResp); err != nil {
-			return fmt.Errorf("error deleting record: %s %s", name, tpe)
-		}
-		return fmt.Errorf("error deleting record: %s %s, reason: %q", name, tpe, errorResp.ErrorMsg)
-	}
+	client.invalidateZoneCache(ctx, zone)
 	return nil
 }
 
@@ -998,37 +684,16 @@ func (client *PowerDNSClient) DeleteRecordSetByID(ctx context.Context, zone stri
 
 // ListViews returns all configured views.
 func (client *PowerDNSClient) ListViews(ctx context.Context) ([]string, error) {
-	req, err := client.newRequest(ctx, http.MethodGet, client.serverEndpoint("/views"), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]any{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return nil, fmt.Errorf("error listing views: failed to decode error response: %w", err)
-		}
-		return nil, fmt.Errorf("error listing views: %q", errorResp.ErrorMsg)
-	}
-
+	// GET /views answers with {"views": [...]}, not a bare array.
 	var wrapper struct {
 		Views []string `json:"views"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
+	_, err := client.do(ctx, requestOptions{
+		endpoint: client.serverEndpoint("/views"),
+		out:      &wrapper,
+		describe: "listing views",
+	})
+	if err != nil {
 		return nil, err
 	}
 
@@ -1037,295 +702,131 @@ func (client *PowerDNSClient) ListViews(ctx context.Context) ([]string, error) {
 
 // GetView retrieves a specific view.
 func (client *PowerDNSClient) GetView(ctx context.Context, viewName string) (*View, error) {
-	req, err := client.newRequest(ctx, http.MethodGet, client.serverEndpoint(fmt.Sprintf("/views/%s", viewName)), nil)
+	var view View
+	_, err := client.do(ctx, requestOptions{
+		endpoint:    client.viewEndpoint(viewName),
+		out:         &view,
+		notFoundErr: ErrNotFound,
+		describe:    fmt.Sprintf("getting view %s", viewName),
+		logFields:   map[string]any{"view": viewName},
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return nil, err
+	if view.Name == "" {
+		view.Name = viewName
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]any{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"view":   viewName,
-			})
-		}
-	}()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		var view View
-		if err := json.NewDecoder(resp.Body).Decode(&view); err != nil {
-			return nil, err
-		}
-		if view.Name == "" {
-			view.Name = viewName
-		}
-		return &view, nil
-	case http.StatusNotFound:
-		return nil, ErrNotFound
-	default:
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return nil, fmt.Errorf("error getting view %s: failed to decode error response: %w", viewName, err)
-		}
-		return nil, fmt.Errorf("error getting view %s: %q", viewName, errorResp.ErrorMsg)
-	}
+	return &view, nil
 }
 
 // AddZoneToView associates a zone with a view.
 func (client *PowerDNSClient) AddZoneToView(ctx context.Context, viewName, zoneName string) error {
-	body, err := json.Marshal(struct {
-		Name string `json:"name"`
-	}{Name: zoneName})
-	if err != nil {
-		return err
-	}
+	_, err := client.do(ctx, requestOptions{
+		method:   http.MethodPost,
+		endpoint: client.viewEndpoint(viewName),
+		body: struct {
+			Name string `json:"name"`
+		}{Name: zoneName},
+		okCodes:   []int{http.StatusOK, http.StatusCreated, http.StatusNoContent},
+		describe:  fmt.Sprintf("adding zone %s to view %s", zoneName, viewName),
+		hint:      viewsHint,
+		logFields: map[string]any{"view": viewName, "zone": zoneName},
+	})
 
-	req, err := client.newRequest(ctx, http.MethodPost, client.serverEndpoint(fmt.Sprintf("/views/%s", viewName)), body)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]any{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"view":   viewName,
-				"zone":   zoneName,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return fmt.Errorf("error adding zone %s to view %s: failed to decode error response: %w", zoneName, viewName, err)
-		}
-		return fmt.Errorf("error adding zone %s to view %s: %q%s", zoneName, viewName,
-			errorResp.ErrorMsg, viewsHint(resp.StatusCode, errorResp.ErrorMsg))
-	}
-
-	return nil
+	return err
 }
 
 // RemoveZoneFromView removes a zone from a view.
 func (client *PowerDNSClient) RemoveZoneFromView(ctx context.Context, viewName, zoneName string) error {
-	req, err := client.newRequest(ctx, http.MethodDelete, client.serverEndpoint(fmt.Sprintf("/views/%s/%s", viewName, zoneName)), nil)
-	if err != nil {
-		return err
-	}
+	_, err := client.do(ctx, requestOptions{
+		method:      http.MethodDelete,
+		endpoint:    client.viewEndpoint(viewName) + "/" + pathEscape(zoneName),
+		okCodes:     []int{http.StatusOK, http.StatusNoContent},
+		notFoundErr: ErrNotFound,
+		describe:    fmt.Sprintf("removing zone %s from view %s", zoneName, viewName),
+		hint:        viewsHint,
+		logFields:   map[string]any{"view": viewName, "zone": zoneName},
+	})
 
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]any{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"view":   viewName,
-				"zone":   zoneName,
-			})
-		}
-	}()
-
-	switch resp.StatusCode {
-	case http.StatusOK, http.StatusNoContent:
-		return nil
-	case http.StatusNotFound:
-		return ErrNotFound
-	default:
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return fmt.Errorf("error removing zone %s from view %s: failed to decode error response: %w", zoneName, viewName, err)
-		}
-		return fmt.Errorf("error removing zone %s from view %s: %q%s", zoneName, viewName,
-			errorResp.ErrorMsg, viewsHint(resp.StatusCode, errorResp.ErrorMsg))
-	}
+	return err
 }
 
 // ListNetworks returns all configured networks.
 func (client *PowerDNSClient) ListNetworks(ctx context.Context) ([]Network, error) {
-	req, err := client.newRequest(ctx, http.MethodGet, client.serverEndpoint("/networks"), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]any{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return nil, fmt.Errorf("error listing networks: failed to decode error response: %w", err)
-		}
-		return nil, fmt.Errorf("error listing networks: %q", errorResp.ErrorMsg)
-	}
-
+	// GET /networks answers with {"networks": [...]}, not a bare array.
 	var wrapper struct {
 		Networks []Network `json:"networks"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
+	_, err := client.do(ctx, requestOptions{
+		endpoint: client.serverEndpoint("/networks"),
+		out:      &wrapper,
+		describe: "listing networks",
+	})
+	if err != nil {
 		return nil, err
 	}
-	networks := wrapper.Networks
 
-	return networks, nil
+	return wrapper.Networks, nil
 }
 
 // GetNetwork retrieves a specific network definition.
 func (client *PowerDNSClient) GetNetwork(ctx context.Context, ip, prefixlen string) (*Network, error) {
-	req, err := client.newRequest(ctx, http.MethodGet, client.serverEndpoint(fmt.Sprintf("/networks/%s/%s", ip, prefixlen)), nil)
+	var network Network
+	_, err := client.do(ctx, requestOptions{
+		endpoint:    client.networkEndpoint(ip, prefixlen),
+		out:         &network,
+		notFoundErr: ErrNotFound,
+		describe:    fmt.Sprintf("getting network %s/%s", ip, prefixlen),
+		logFields:   map[string]any{"ip": ip, "prefix_len": prefixlen},
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]any{
-				"error":      err.Error(),
-				"method":     req.Method,
-				"url":        req.URL.String(),
-				"ip":         ip,
-				"prefix_len": prefixlen,
-			})
-		}
-	}()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		var network Network
-		if err := json.NewDecoder(resp.Body).Decode(&network); err != nil {
-			return nil, err
-		}
-		return &network, nil
-	case http.StatusNotFound:
-		return nil, ErrNotFound
-	default:
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return nil, fmt.Errorf("error getting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
-		}
-		return nil, fmt.Errorf("error getting network %s/%s: %q", ip, prefixlen, errorResp.ErrorMsg)
-	}
+	return &network, nil
 }
 
 // SetNetwork creates or updates a network definition.
 func (client *PowerDNSClient) SetNetwork(ctx context.Context, ip, prefixlen, view string) error {
-	body, err := json.Marshal(Network{View: view})
-	if err != nil {
-		return err
-	}
+	_, err := client.do(ctx, requestOptions{
+		method:    http.MethodPut,
+		endpoint:  client.networkEndpoint(ip, prefixlen),
+		body:      Network{View: view},
+		okCodes:   []int{http.StatusOK, http.StatusCreated, http.StatusNoContent},
+		describe:  fmt.Sprintf("setting network %s/%s", ip, prefixlen),
+		hint:      viewsHint,
+		logFields: map[string]any{"ip": ip, "prefix_len": prefixlen, "view": view},
+	})
 
-	req, err := client.newRequest(ctx, http.MethodPut, client.serverEndpoint(fmt.Sprintf("/networks/%s/%s", ip, prefixlen)), body)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]any{
-				"error":      err.Error(),
-				"method":     req.Method,
-				"url":        req.URL.String(),
-				"ip":         ip,
-				"prefix_len": prefixlen,
-				"view":       view,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return fmt.Errorf("error setting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
-		}
-		return fmt.Errorf("error setting network %s/%s: %q%s", ip, prefixlen,
-			errorResp.ErrorMsg, viewsHint(resp.StatusCode, errorResp.ErrorMsg))
-	}
-
-	return nil
+	return err
 }
 
-// DeleteNetwork deletes a network definition.
+// DeleteNetwork deletes a network definition by clearing its view.
 func (client *PowerDNSClient) DeleteNetwork(ctx context.Context, ip, prefixlen string) error {
-	body, err := json.Marshal(Network{View: ""})
-	if err != nil {
-		return err
-	}
+	_, err := client.do(ctx, requestOptions{
+		method:      http.MethodPut,
+		endpoint:    client.networkEndpoint(ip, prefixlen),
+		body:        Network{View: ""},
+		okCodes:     []int{http.StatusOK, http.StatusCreated, http.StatusNoContent},
+		notFoundErr: ErrNotFound,
+		describe:    fmt.Sprintf("deleting network %s/%s", ip, prefixlen),
+		hint:        viewsHint,
+		logFields:   map[string]any{"ip": ip, "prefix_len": prefixlen},
+	})
 
-	req, err := client.newRequest(ctx, http.MethodPut, client.serverEndpoint(fmt.Sprintf("/networks/%s/%s", ip, prefixlen)), body)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]any{
-				"error":      err.Error(),
-				"method":     req.Method,
-				"url":        req.URL.String(),
-				"ip":         ip,
-				"prefix_len": prefixlen,
-			})
-		}
-	}()
-
-	switch resp.StatusCode {
-	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
-		return nil
-	case http.StatusNotFound:
-		return ErrNotFound
-	default:
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return fmt.Errorf("error deleting network %s/%s: failed to decode error response: %w", ip, prefixlen, err)
-		}
-		return fmt.Errorf("error deleting network %s/%s: %q%s", ip, prefixlen,
-			errorResp.ErrorMsg, viewsHint(resp.StatusCode, errorResp.ErrorMsg))
-	}
+	return err
 }
 
 // RecursorClient talks to the PowerDNS Recursor API.
 type RecursorClient struct {
 	*BaseClient
+}
+
+// serverEndpoint returns an API path scoped to the recursor server. The
+// recursor exposes only "localhost", unlike the authoritative server.
+func (client *RecursorClient) serverEndpoint(path string) string {
+	return "/servers/localhost" + path
 }
 
 // RecursorForwardZone represents a PowerDNS Recursor forward zone.
@@ -1364,217 +865,87 @@ func NewRecursorClient(
 
 // GetForwardZone retrieves a specific recursor forward zone definition.
 func (client *RecursorClient) GetForwardZone(ctx context.Context, name string) (*RecursorForwardZone, error) {
-	endpoint := fmt.Sprintf("/servers/localhost/zones/%s", name)
-
-	req, err := client.newRequest(ctx, http.MethodGet, endpoint, nil)
+	var zone RecursorForwardZone
+	_, err := client.do(ctx, requestOptions{
+		endpoint:    client.serverEndpoint("/zones/" + pathEscape(name)),
+		out:         &zone,
+		notFoundErr: ErrNotFound,
+		describe:    fmt.Sprintf("getting forward zone %s", name),
+		logFields:   map[string]any{"zone": name},
+	})
 	if err != nil {
-		return nil, err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   name,
-			})
-		}
-	}()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		var zone RecursorForwardZone
-		if err := json.NewDecoder(resp.Body).Decode(&zone); err != nil {
-			return nil, err
-		}
-		return &zone, nil
-
-	case http.StatusNotFound:
-		return nil, ErrNotFound
-
-	default:
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return nil, fmt.Errorf("error getting forward zone %s", name)
-		}
-		if strings.Contains(errorResp.ErrorMsg, "Could not find domain") {
+		// The recursor answers an unknown zone with a 422 rather than a 404,
+		// so the absence has to be recognised from the message itself.
+		if strings.Contains(err.Error(), "Could not find domain") {
 			return nil, ErrNotFound
 		}
-		return nil, fmt.Errorf("error getting forward zone %s: %q", name, errorResp.ErrorMsg)
+		return nil, err
 	}
+
+	return &zone, nil
 }
 
 // CreateForwardZone creates a recursor forward zone.
 func (client *RecursorClient) CreateForwardZone(ctx context.Context, zone *RecursorForwardZone) error {
-	body, err := json.Marshal(zone)
-	if err != nil {
-		return err
-	}
+	_, err := client.do(ctx, requestOptions{
+		method:    http.MethodPost,
+		endpoint:  client.serverEndpoint("/zones"),
+		body:      zone,
+		out:       nil,
+		okCodes:   []int{http.StatusCreated},
+		describe:  fmt.Sprintf("creating forward zone %s", zone.Name),
+		hint:      recursorMessageHint,
+		logFields: map[string]any{"zone": zone.Name},
+	})
 
-	req, err := client.newRequest(ctx, http.MethodPost, "/servers/localhost/zones", body)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   zone.Name,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusCreated {
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return fmt.Errorf("error creating forward zone %s", zone.Name)
-		}
-		return fmt.Errorf("error creating forward zone %s: %q%s", zone.Name,
-			errorResp.ErrorMsg, recursorHint(errorResp.ErrorMsg))
-	}
-
-	return nil
+	return err
 }
 
 // DeleteForwardZone deletes a recursor forward zone.
 func (client *RecursorClient) DeleteForwardZone(ctx context.Context, name string) error {
-	endpoint := fmt.Sprintf("/servers/localhost/zones/%s", name)
+	_, err := client.do(ctx, requestOptions{
+		method:      http.MethodDelete,
+		endpoint:    client.serverEndpoint("/zones/" + pathEscape(name)),
+		okCodes:     []int{http.StatusNoContent, http.StatusOK},
+		notFoundErr: ErrNotFound,
+		describe:    fmt.Sprintf("deleting forward zone %s", name),
+		hint:        recursorMessageHint,
+		logFields:   map[string]any{"zone": name},
+	})
 
-	req, err := client.newRequest(ctx, http.MethodDelete, endpoint, nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]interface{}{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"zone":   name,
-			})
-		}
-	}()
-
-	switch resp.StatusCode {
-	case http.StatusNoContent, http.StatusOK:
-		return nil
-
-	case http.StatusNotFound:
-		return ErrNotFound
-
-	default:
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return fmt.Errorf("error deleting forward zone %s", name)
-		}
-		return fmt.Errorf("error deleting forward zone %s: %q%s", name,
-			errorResp.ErrorMsg, recursorHint(errorResp.ErrorMsg))
-	}
+	return err
 }
 
-// GetConfig retrieves a single recursor config setting using
+// GetConfig retrieves a single recursor config setting.
 func (client *RecursorClient) GetConfig(ctx context.Context, name string) (*RecursorConfigSetting, error) {
-	endpoint := fmt.Sprintf("/servers/localhost/config/%s", name)
-
-	req, err := client.newRequest(ctx, http.MethodGet, endpoint, nil)
+	var setting RecursorConfigSetting
+	_, err := client.do(ctx, requestOptions{
+		endpoint:    client.serverEndpoint("/config/" + pathEscape(name)),
+		out:         &setting,
+		notFoundErr: ErrNotFound,
+		describe:    fmt.Sprintf("getting recursor config %s", name),
+		logFields:   map[string]any{"name": name},
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]any{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"name":   name,
-			})
-		}
-	}()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		var setting RecursorConfigSetting
-		if err := json.NewDecoder(resp.Body).Decode(&setting); err != nil {
-			return nil, err
-		}
-		return &setting, nil
-
-	case http.StatusNotFound:
-		return nil, ErrNotFound
-
-	default:
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return nil, fmt.Errorf("error getting recursor config %s", name)
-		}
-		return nil, fmt.Errorf("error getting recursor config %s: %q", name, errorResp.ErrorMsg)
-	}
+	return &setting, nil
 }
 
-// SetConfig changes a single recursor config setting using
+// SetConfig changes a single recursor config setting.
 func (client *RecursorClient) SetConfig(ctx context.Context, name string, values []string) error {
-	setting := RecursorConfigSetting{
-		Name:  name,
-		Value: values,
-	}
+	_, err := client.do(ctx, requestOptions{
+		method:   http.MethodPut,
+		endpoint: client.serverEndpoint("/config/" + pathEscape(name)),
+		body: RecursorConfigSetting{
+			Name:  name,
+			Value: values,
+		},
+		describe:  fmt.Sprintf("setting recursor config %s", name),
+		hint:      recursorMessageHint,
+		logFields: map[string]any{"name": name},
+	})
 
-	body, err := json.Marshal(&setting)
-	if err != nil {
-		return err
-	}
-
-	endpoint := fmt.Sprintf("/servers/localhost/config/%s", name)
-
-	req, err := client.newRequest(ctx, http.MethodPut, endpoint, body)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			tflog.Warn(ctx, "Error closing response body", map[string]any{
-				"error":  err.Error(),
-				"method": req.Method,
-				"url":    req.URL.String(),
-				"name":   name,
-			})
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		var errorResp errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
-			return fmt.Errorf("error setting recursor config %s", name)
-		}
-		return fmt.Errorf("error setting recursor config %s: %q%s", name,
-			errorResp.ErrorMsg, recursorHint(errorResp.ErrorMsg))
-	}
-
-	return nil
+	return err
 }

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -25,12 +25,6 @@ var DefaultSchema = "https"
 // <scheme>://<host>[:port]
 // with no trailing /
 func sanitizeURL(URL string) (string, error) {
-	cleanURL := ""
-	host := ""
-	schema := ""
-
-	var err error
-
 	if len(URL) == 0 {
 		return "", fmt.Errorf("no URL provided")
 	}
@@ -40,31 +34,27 @@ func sanitizeURL(URL string) (string, error) {
 		return "", fmt.Errorf("error while trying to parse URL: %s", err)
 	}
 
-	if len(parsedURL.Scheme) == 0 {
-		schema = DefaultSchema
-	} else {
-		if parsedURL.Scheme == "http" || parsedURL.Scheme == "https" {
-			schema = parsedURL.Scheme
-		} else {
-			schema = DefaultSchema
-		}
+	// Anything that is not plain HTTP falls back to the default rather than
+	// being rejected, so a bare "host:8081" still reaches the server.
+	schema := DefaultSchema
+	switch parsedURL.Scheme {
+	case "http", "https":
+		schema = parsedURL.Scheme
 	}
 
-	if len(parsedURL.Host) == 0 {
-		tryout, _ := url.Parse(schema + "://" + URL)
-
-		if len(tryout.Host) == 0 {
+	host := parsedURL.Host
+	if len(host) == 0 {
+		// Without a scheme, url.Parse treats the whole value as a path, so
+		// reparse it with one attached to recover the host.
+		tryout, err := url.Parse(schema + "://" + URL)
+		if err != nil || len(tryout.Host) == 0 {
 			return "", fmt.Errorf("unable to find a hostname in '%s'", URL)
 		}
 
 		host = tryout.Host
-	} else {
-		host = parsedURL.Host
 	}
 
-	cleanURL = schema + "://" + host
-
-	return cleanURL, nil
+	return schema + "://" + host, nil
 }
 
 // BaseClient contains shared HTTP / auth / cache logic for PowerDNS-style APIs.
@@ -580,17 +570,35 @@ func (client *PowerDNSClient) ListRecordsByID(ctx context.Context, zone string, 
 }
 
 // GetRecordSetByID returns the full RRset (including comments) for the given ID.
+//
+// The lookup is pushed to the server with rrset_name/rrset_type so a zone with
+// thousands of RRsets does not have to be transferred and decoded to find one.
+// A server that predates those parameters ignores them and returns the whole
+// zone, which the same match below narrows down, so no version check is needed.
 func (client *PowerDNSClient) GetRecordSetByID(ctx context.Context, zone string, recID string) (*ResourceRecordSet, error) {
 	name, tpe, err := parseID(recID)
 	if err != nil {
 		return nil, err
 	}
 
-	zoneInfo, err := client.GetZoneWithRRsets(ctx, zone)
+	query := url.Values{}
+	query.Set("rrsets", "true")
+	query.Set("rrset_name", name)
+	query.Set("rrset_type", tpe)
+
+	var zoneInfo ZoneInfo
+	_, err = client.do(ctx, requestOptions{
+		endpoint:  client.zoneEndpoint(zone) + "?" + query.Encode(),
+		out:       &zoneInfo,
+		describe:  fmt.Sprintf("getting zone: %s", zone),
+		logFields: map[string]any{"zone": zone, "rrsetId": recID},
+	})
 	if err != nil {
 		return nil, err
 	}
 
+	// The filter is matched case-insensitively by the server, but an older
+	// server ignores it outright, so the match still has to be made here.
 	for i := range zoneInfo.ResourceRecordSets {
 		rrSet := &zoneInfo.ResourceRecordSets[i]
 		if strings.EqualFold(rrSet.Name, name) && strings.EqualFold(rrSet.Type, tpe) {

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -139,7 +139,7 @@ func (client *BaseClient) newRequest(ctx context.Context, method string, endpoin
 		bodyReader = bytes.NewReader(body)
 	}
 
-	req, err := http.NewRequest(method, u.String(), bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("error during creation of request: %s", err)
 	}
@@ -165,7 +165,7 @@ func (client *BaseClient) detectAPIVersion(ctx context.Context) (int, error) {
 		return -1, fmt.Errorf("error while trying to detect the API version, request URL: %s", err)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return -1, fmt.Errorf("error during creation of request: %s", err)
 	}
@@ -902,9 +902,12 @@ func (client *PowerDNSClient) RecordExistsByID(ctx context.Context, zone string,
 func (client *PowerDNSClient) ReplaceRecordSet(ctx context.Context, zone string, rrSet ResourceRecordSet) (string, error) {
 	rrSet.ChangeType = "REPLACE"
 
-	reqBody, _ := json.Marshal(zonePatchRequest{
+	reqBody, err := json.Marshal(zonePatchRequest{
 		RecordSets: []ResourceRecordSet{rrSet},
 	})
+	if err != nil {
+		return "", err
+	}
 
 	req, err := client.newRequest(ctx, http.MethodPatch, client.serverEndpoint(fmt.Sprintf("/zones/%s", zone)), reqBody)
 	if err != nil {
@@ -939,7 +942,7 @@ func (client *PowerDNSClient) ReplaceRecordSet(ctx context.Context, zone string,
 
 // DeleteRecordSet deletes record set from Zone
 func (client *PowerDNSClient) DeleteRecordSet(ctx context.Context, zone string, name string, tpe string) error {
-	reqBody, _ := json.Marshal(zonePatchRequest{
+	reqBody, err := json.Marshal(zonePatchRequest{
 		RecordSets: []ResourceRecordSet{
 			{
 				Name:       name,
@@ -948,6 +951,9 @@ func (client *PowerDNSClient) DeleteRecordSet(ctx context.Context, zone string, 
 			},
 		},
 	})
+	if err != nil {
+		return err
+	}
 
 	req, err := client.newRequest(ctx, http.MethodPatch, client.serverEndpoint(fmt.Sprintf("/zones/%s", zone)), reqBody)
 	if err != nil {

--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -454,6 +454,21 @@ func (client *PowerDNSClient) DeleteZoneMetadata(ctx context.Context, zone strin
 	return err
 }
 
+// zoneCacheKey is the cache key for a zone. DNS names are case-insensitive, so
+// "example.com." and "Example.COM." name one zone and must share one entry:
+// keying on the caller's spelling would let a write under one spelling leave a
+// stale entry under another. Only the zone part is lowered - a PowerDNS zone
+// variant ("example.com..internal") keeps its variant suffix verbatim, since
+// that is an API identifier rather than a DNS name.
+func zoneCacheKey(zone string) []byte {
+	name, variant, hasVariant := strings.Cut(zone, "..")
+	key := strings.ToLower(name)
+	if hasVariant {
+		key += ".." + variant
+	}
+	return []byte(key)
+}
+
 // getCachedZoneInfo returns the cached ZoneInfo for a zone. found is false when
 // caching is disabled or the zone is simply not cached yet; only a malformed
 // cache entry is reported as an error.
@@ -462,7 +477,8 @@ func (client *PowerDNSClient) getCachedZoneInfo(ctx context.Context, zone string
 		return nil, false, nil
 	}
 
-	cached, err := client.Cache.Get([]byte(zone))
+	key := zoneCacheKey(zone)
+	cached, err := client.Cache.Get(key)
 	if err != nil {
 		// freecache reports an ordinary miss as an error; that is not a failure.
 		return nil, false, nil
@@ -474,7 +490,7 @@ func (client *PowerDNSClient) getCachedZoneInfo(ctx context.Context, zone string
 			"zone":  zone,
 			"error": err.Error(),
 		})
-		client.Cache.Del([]byte(zone))
+		client.Cache.Del(key)
 		return nil, false, nil
 	}
 
@@ -489,7 +505,7 @@ func (client *PowerDNSClient) invalidateZoneCache(ctx context.Context, zone stri
 		return
 	}
 
-	if client.Cache.Del([]byte(zone)) {
+	if client.Cache.Del(zoneCacheKey(zone)) {
 		tflog.Debug(ctx, "Invalidated zone cache", map[string]any{"zone": zone})
 	}
 }
@@ -528,7 +544,7 @@ func (client *PowerDNSClient) ListRecords(ctx context.Context, zone string) ([]R
 				return nil, err
 			}
 
-			if err := client.Cache.Set([]byte(zone), cacheValue, client.CacheTTL); err != nil {
+			if err := client.Cache.Set(zoneCacheKey(zone), cacheValue, client.CacheTTL); err != nil {
 				return nil, fmt.Errorf("the cache for REST API requests is enabled but the size isn't enough: cacheSize: %db: %w", client.CacheSize, err)
 			}
 		}

--- a/powerdns/client_metadata_test.go
+++ b/powerdns/client_metadata_test.go
@@ -177,7 +177,12 @@ func TestGetRecordSetByIDWithComments(t *testing.T) {
 	client := newTestClient(func(r *http.Request) (*http.Response, error) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/v1/servers/localhost/zones/example.com.", r.URL.Path)
-		assert.Equal(t, "rrsets=true", r.URL.RawQuery)
+		// The RRset lookup is filtered server-side so a large zone is not
+		// transferred in full just to find one record set.
+		query := r.URL.Query()
+		assert.Equal(t, "true", query.Get("rrsets"))
+		assert.Equal(t, "www.example.com.", query.Get("rrset_name"))
+		assert.Equal(t, "A", query.Get("rrset_type"))
 		return jsonResponse(http.StatusOK, `{
 			"name":"example.com.",
 			"rrsets":[

--- a/powerdns/client_zone_recursor_test.go
+++ b/powerdns/client_zone_recursor_test.go
@@ -1,0 +1,244 @@
+package powerdns
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newRecursorTestClient(fn roundTripFunc) *RecursorClient {
+	return &RecursorClient{BaseClient: &BaseClient{
+		ServerURL:  "https://pdns.example.test",
+		APIKey:     "test-key",
+		APIVersion: 1,
+		HTTP:       &http.Client{Transport: fn},
+	}}
+}
+
+// The recursor reports an unknown forward zone with a 422 and an explanatory
+// message rather than a 404, so absence is recognised by matching that message
+// inside the error statusError builds. This test pins the two together: if the
+// wording on either side drifts apart, a missing zone starts surfacing as a
+// hard failure and Terraform reports an error instead of planning a create.
+func TestGetForwardZoneTreats422AsNotFound(t *testing.T) {
+	client := newRecursorTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		return jsonResponse(http.StatusUnprocessableEntity,
+			`{"error":"Could not find domain 'example.com.'"}`), nil
+	})
+
+	zone, err := client.GetForwardZone(context.Background(), "example.com.")
+	assert.Nil(t, zone)
+	assert.True(t, errors.Is(err, ErrNotFound),
+		"a 422 naming a missing domain must be reported as ErrNotFound, got: %v", err)
+}
+
+// A 404 is mapped to ErrNotFound by the shared request layer rather than by the
+// message match above.
+func TestGetForwardZoneTreats404AsNotFound(t *testing.T) {
+	client := newRecursorTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, `{"error":"Not Found"}`), nil
+	})
+
+	zone, err := client.GetForwardZone(context.Background(), "example.com.")
+	assert.Nil(t, zone)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+// A rejection that is not about a missing domain must stay an error, otherwise
+// a genuine failure would be silently read as "zone absent" and Terraform would
+// try to recreate a zone that is already there.
+func TestGetForwardZoneOtherErrorIsNotNotFound(t *testing.T) {
+	client := newRecursorTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusUnprocessableEntity,
+			`{"error":"Unable to parse forwarder address"}`), nil
+	})
+
+	zone, err := client.GetForwardZone(context.Background(), "example.com.")
+	assert.Nil(t, zone)
+	if !assert.Error(t, err) {
+		return
+	}
+	assert.False(t, errors.Is(err, ErrNotFound))
+	assert.Contains(t, err.Error(), "Unable to parse forwarder address")
+}
+
+func TestGetForwardZoneSuccess(t *testing.T) {
+	client := newRecursorTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK,
+			`{"name":"example.com.","servers":["192.0.2.1:5300"],"recursion_desired":true}`), nil
+	})
+
+	zone, err := client.GetForwardZone(context.Background(), "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "example.com.", zone.Name)
+	assert.Equal(t, []string{"192.0.2.1:5300"}, zone.Servers)
+}
+
+// ZoneExists is one of the few callers that treats a non-success status as data
+// rather than as a failure, reading the status code the request layer returns
+// alongside the error. Both branches of that contract are checked here.
+func TestZoneExistsReportsPresence(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/servers/localhost/zones/example.com.", r.URL.Path)
+		return jsonResponse(http.StatusOK, `{"id":"example.com.","name":"example.com."}`), nil
+	})
+
+	exists, err := client.ZoneExists(context.Background(), "example.com.")
+	assert.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestZoneExistsReportsAbsence(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, `{"error":"Not Found"}`), nil
+	})
+
+	exists, err := client.ZoneExists(context.Background(), "example.com.")
+	assert.NoError(t, err, "a 404 means the zone is absent, not that the lookup failed")
+	assert.False(t, exists)
+}
+
+// A status outside the accepted set is still a real failure and must not be
+// reported as a confident "zone does not exist".
+func TestZoneExistsSurfacesUnexpectedStatus(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusInternalServerError, `{"error":"backend unavailable"}`), nil
+	})
+
+	exists, err := client.ZoneExists(context.Background(), "example.com.")
+	assert.Error(t, err)
+	assert.False(t, exists)
+}
+
+func TestCreateZone(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/servers/localhost/zones", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		return jsonResponse(http.StatusCreated,
+			`{"id":"example.com.","name":"example.com.","kind":"Native"}`), nil
+	})
+
+	zone, err := client.CreateZone(context.Background(), ZoneInfo{Name: "example.com.", Kind: "Native"})
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "example.com.", zone.Name)
+	assert.Equal(t, "Native", zone.Kind)
+}
+
+// Only a 201 counts as a created zone; anything else must surface the server's
+// own message rather than being decoded as success.
+func TestCreateZoneRejectsUnexpectedStatus(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusConflict, `{"error":"Domain already exists"}`), nil
+	})
+
+	_, err := client.CreateZone(context.Background(), ZoneInfo{Name: "example.com."})
+	if !assert.Error(t, err) {
+		return
+	}
+	assert.Contains(t, err.Error(), "Domain already exists")
+}
+
+// UpdateZone and DeleteZone both drop the zone from the cache on success, so a
+// read issued straight afterwards must go back to the server rather than being
+// served the pre-write copy.
+func TestUpdateZoneInvalidatesZoneCache(t *testing.T) {
+	var listCalls int32
+
+	client := newCachingTestClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet {
+			atomic.AddInt32(&listCalls, 1)
+			return jsonResponse(http.StatusOK, oneRecordZone), nil
+		}
+		assert.Equal(t, http.MethodPut, r.Method)
+		return jsonResponse(http.StatusNoContent, ``), nil
+	})
+
+	ctx := context.Background()
+
+	_, err := client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	if !assert.NoError(t, client.UpdateZone(ctx, "example.com.", ZoneInfoUpd{Kind: "Native"})) {
+		return
+	}
+
+	_, err = client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, int32(2), atomic.LoadInt32(&listCalls),
+		"read after update should refetch instead of serving the stale zone")
+}
+
+func TestDeleteZoneInvalidatesZoneCache(t *testing.T) {
+	var listCalls int32
+
+	client := newCachingTestClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet {
+			atomic.AddInt32(&listCalls, 1)
+			return jsonResponse(http.StatusOK, oneRecordZone), nil
+		}
+		assert.Equal(t, http.MethodDelete, r.Method)
+		return jsonResponse(http.StatusNoContent, ``), nil
+	})
+
+	ctx := context.Background()
+
+	_, err := client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	if !assert.NoError(t, client.DeleteZone(ctx, "example.com.")) {
+		return
+	}
+
+	_, err = client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, int32(2), atomic.LoadInt32(&listCalls))
+}
+
+// A failed write must leave the cache alone: the zone on the server did not
+// change, so dropping the entry would cost an extra refetch for nothing.
+func TestFailedZoneWriteKeepsCache(t *testing.T) {
+	var listCalls int32
+
+	client := newCachingTestClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet {
+			atomic.AddInt32(&listCalls, 1)
+			return jsonResponse(http.StatusOK, oneRecordZone), nil
+		}
+		return jsonResponse(http.StatusInternalServerError, `{"error":"backend unavailable"}`), nil
+	})
+
+	ctx := context.Background()
+
+	_, err := client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Error(t, client.UpdateZone(ctx, "example.com.", ZoneInfoUpd{Kind: "Native"}))
+
+	_, err = client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&listCalls),
+		"a failed write should leave the cached zone in place")
+}

--- a/powerdns/provider.go
+++ b/powerdns/provider.go
@@ -140,10 +140,10 @@ func providerConfigure(ctx context.Context, data *schema.ResourceData) (interfac
 		}
 	}
 
-	tflog.SetField(ctx, "server_url", config.ServerURL)
-	tflog.SetField(ctx, "server_id", config.ServerID)
+	ctx = tflog.SetField(ctx, "server_url", config.ServerURL)
+	ctx = tflog.SetField(ctx, "server_id", config.ServerID)
 	if config.RecursorServerURL != "" {
-		tflog.SetField(ctx, "recursor_server_url", config.RecursorServerURL)
+		ctx = tflog.SetField(ctx, "recursor_server_url", config.RecursorServerURL)
 	}
 	tflog.Debug(ctx, "Initializing PowerDNS client")
 

--- a/powerdns/request.go
+++ b/powerdns/request.go
@@ -1,0 +1,235 @@
+package powerdns
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// requestOptions describes a single API call. Every PowerDNS endpoint differs
+// only in which statuses it treats as success, whether a 404 is a real absence
+// rather than a failure, and which backend hint explains a rejection, so those
+// are the only knobs here.
+type requestOptions struct {
+	// method is the HTTP method; defaults to GET when empty.
+	method string
+	// endpoint is the API path, already escaped by pathEscape.
+	endpoint string
+	// body, when non-nil, is marshalled as the JSON request body.
+	body any
+	// out, when non-nil, receives the decoded JSON response body.
+	out any
+	// okCodes lists the statuses that count as success. Defaults to 200.
+	okCodes []int
+	// notFoundErr, when set, is returned instead of a generic error for a 404.
+	notFoundErr error
+	// describe names the operation for error messages, e.g. `zone "example.com."`.
+	describe string
+	// hint optionally expands on a server rejection; see backend_hints.go.
+	hint func(statusCode int, serverMessage string) string
+	// logFields are attached to the response-close warning, if any.
+	logFields map[string]any
+}
+
+// pathEscape escapes a single path segment for use in an API endpoint. Zone
+// names, metadata kinds and view names all reach the API as user input and can
+// legitimately contain characters that would otherwise change the request path.
+func pathEscape(segment string) string {
+	return url.PathEscape(segment)
+}
+
+// do performs one API request end to end: it marshals the body, sends the
+// request, closes the response, maps the status to an error or to ErrNotFound,
+// and decodes the payload into opts.out.
+//
+// It returns the status code alongside the error so the few callers that treat
+// a non-success status as data (rather than as a failure) can inspect it.
+func (client *BaseClient) do(ctx context.Context, opts requestOptions) (int, error) {
+	method := opts.method
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	var body []byte
+	if opts.body != nil {
+		var err error
+		if body, err = json.Marshal(opts.body); err != nil {
+			return 0, fmt.Errorf("error encoding request for %s: %w", opts.describe, err)
+		}
+	}
+
+	req, err := client.newRequest(ctx, method, opts.endpoint, body)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fields := map[string]any{
+				"error":  err.Error(),
+				"method": req.Method,
+				"url":    req.URL.String(),
+			}
+			for k, v := range opts.logFields {
+				fields[k] = v
+			}
+			tflog.Warn(ctx, "Error closing response body", fields)
+		}
+	}()
+
+	okCodes := opts.okCodes
+	if len(okCodes) == 0 {
+		okCodes = []int{http.StatusOK}
+	}
+
+	if !containsStatus(okCodes, resp.StatusCode) {
+		if opts.notFoundErr != nil && resp.StatusCode == http.StatusNotFound {
+			return resp.StatusCode, opts.notFoundErr
+		}
+		return resp.StatusCode, client.statusError(resp, opts)
+	}
+
+	if opts.out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(opts.out); err != nil {
+			return resp.StatusCode, fmt.Errorf("error decoding response for %s: %w", opts.describe, err)
+		}
+	}
+
+	return resp.StatusCode, nil
+}
+
+// statusError turns an unexpected status into an error, preferring the server's
+// own message and appending a backend hint when one applies.
+func (client *BaseClient) statusError(resp *http.Response, opts requestOptions) error {
+	var errorResp errorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
+		// The body was not the JSON error envelope the API documents, so the
+		// status and the decode failure are all there is to report.
+		return fmt.Errorf("error with %s: %s: failed to decode error response: %w",
+			opts.describe, resp.Status, err)
+	}
+
+	hint := ""
+	if opts.hint != nil {
+		hint = opts.hint(resp.StatusCode, errorResp.ErrorMsg)
+	}
+
+	return fmt.Errorf("error with %s, reason: %q%s", opts.describe, errorResp.ErrorMsg, hint)
+}
+
+func containsStatus(codes []int, code int) bool {
+	for _, c := range codes {
+		if c == code {
+			return true
+		}
+	}
+	return false
+}
+
+// newRequest creates a new request against the API with necessary headers.
+func (client *BaseClient) newRequest(ctx context.Context, method string, endpoint string, body []byte) (*http.Request, error) {
+	apiVersion, err := client.apiVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var urlStr string
+	if apiVersion > 0 {
+		urlStr = client.ServerURL + "/api/v" + strconv.Itoa(apiVersion) + endpoint
+	} else {
+		urlStr = client.ServerURL + endpoint
+	}
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("error during parsing request URL: %s", err)
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("error during creation of request: %s", err)
+	}
+
+	req.Header.Add("X-API-Key", client.APIKey)
+	req.Header.Add("Accept", "application/json")
+
+	if method != http.MethodGet {
+		req.Header.Add("Content-Type", "application/json")
+	}
+
+	return req, nil
+}
+
+// apiVersion returns the server's API version, detecting it at most once even
+// when Terraform walks the resource graph in parallel over a shared client.
+// A version already set on the client (APIVersion >= 0) is taken as given and
+// suppresses detection entirely.
+func (client *BaseClient) apiVersion(ctx context.Context) (int, error) {
+	client.apiVersionOnce.Do(func() {
+		if client.APIVersion >= 0 {
+			return
+		}
+
+		version, err := client.detectAPIVersion(ctx)
+		if err != nil {
+			client.apiVersionErr = err
+			return
+		}
+		client.APIVersion = version
+	})
+
+	return client.APIVersion, client.apiVersionErr
+}
+
+// detectAPIVersion detects the API version in use on the server.
+// Uses int to represent the API version: 0 is the legacy AKA version 3.4 API.
+// Any other integer correlates with the same API version.
+func (client *BaseClient) detectAPIVersion(ctx context.Context) (int, error) {
+	u, err := url.Parse(client.ServerURL + "/api/v1/servers")
+	if err != nil {
+		return -1, fmt.Errorf("error while trying to detect the API version, request URL: %s", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return -1, fmt.Errorf("error during creation of request: %s", err)
+	}
+
+	req.Header.Add("X-API-Key", client.APIKey)
+	req.Header.Add("Accept", "application/json")
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return -1, err
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			tflog.Warn(ctx, "Error closing response body", map[string]any{
+				"error":  err.Error(),
+				"method": req.Method,
+				"url":    req.URL.String(),
+			})
+		}
+	}()
+
+	if resp.StatusCode == http.StatusOK {
+		return 1, nil
+	}
+	return 0, nil
+}

--- a/powerdns/request_test.go
+++ b/powerdns/request_test.go
@@ -166,6 +166,85 @@ func TestDeleteRecordSetInvalidatesZoneCache(t *testing.T) {
 	assert.Equal(t, int32(2), atomic.LoadInt32(&listCalls))
 }
 
+// DNS names are case-insensitive, so two config sites naming one zone with
+// different capitalisation must share a cache entry rather than each getting
+// their own.
+func TestZoneCacheKeyIsCaseInsensitive(t *testing.T) {
+	var listCalls int32
+
+	client := newCachingTestClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet {
+			atomic.AddInt32(&listCalls, 1)
+			return jsonResponse(http.StatusOK, oneRecordZone), nil
+		}
+		return jsonResponse(http.StatusNoContent, ``), nil
+	})
+
+	ctx := context.Background()
+
+	_, err := client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	_, err = client.ListRecords(ctx, "Example.COM.")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&listCalls),
+		"a case variant of a cached zone should hit the same cache entry")
+}
+
+// A write must invalidate the zone whatever capitalisation it is spelled with,
+// or the stale entry under the other spelling is served as drift.
+func TestWriteInvalidatesZoneCacheAcrossCase(t *testing.T) {
+	var listCalls int32
+
+	client := newCachingTestClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet {
+			atomic.AddInt32(&listCalls, 1)
+			return jsonResponse(http.StatusOK, oneRecordZone), nil
+		}
+		return jsonResponse(http.StatusNoContent, ``), nil
+	})
+
+	ctx := context.Background()
+
+	_, err := client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	_, err = client.ReplaceRecordSet(ctx, "EXAMPLE.com.", ResourceRecordSet{
+		Name:    "www.example.com.",
+		Type:    "A",
+		TTL:     300,
+		Records: []Record{{Content: "192.0.2.2"}},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	_, err = client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, int32(2), atomic.LoadInt32(&listCalls),
+		"a write spelled with different case should still invalidate the zone")
+}
+
+// Zone variants are distinct zones in PowerDNS: the name is case-insensitive
+// but the variant suffix is an API identifier and must stay verbatim.
+func TestZoneCacheKeyPreservesVariant(t *testing.T) {
+	assert.Equal(t, "example.com.", string(zoneCacheKey("Example.COM.")))
+
+	// The base is lowered, the variant suffix is left exactly as given.
+	assert.Equal(t, "example.com..internal", string(zoneCacheKey("Example.COM..internal")))
+
+	// A variant is a different zone from the plain name and must not collide.
+	assert.NotEqual(t, string(zoneCacheKey("example.com.")), string(zoneCacheKey("example.com..internal")))
+}
+
 // Path segments reach the API as user input and must not be able to alter the
 // request path.
 func TestEndpointsEscapePathSegments(t *testing.T) {

--- a/powerdns/request_test.go
+++ b/powerdns/request_test.go
@@ -1,0 +1,207 @@
+package powerdns
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	freecache "github.com/coocood/freecache"
+	"github.com/stretchr/testify/assert"
+)
+
+// A single client is shared across the whole provider while Terraform walks the
+// resource graph in parallel, so version detection must happen exactly once no
+// matter how many resources issue their first request simultaneously.
+func TestAPIVersionDetectedOnceUnderConcurrency(t *testing.T) {
+	var detections int32
+
+	client := &PowerDNSClient{
+		serverID: "localhost",
+		BaseClient: &BaseClient{
+			ServerURL:  "https://pdns.example.test",
+			APIKey:     "test-key",
+			APIVersion: -1,
+			HTTP: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if r.URL.Path == "/api/v1/servers" {
+					atomic.AddInt32(&detections, 1)
+				}
+				return jsonResponse(http.StatusOK, `[]`), nil
+			})},
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = client.ListZones(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&detections),
+		"API version should be probed exactly once across concurrent callers")
+}
+
+// A version already present on the client is authoritative and must not trigger
+// a probe.
+func TestAPIVersionPresetSkipsDetection(t *testing.T) {
+	var detections int32
+
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/api/v1/servers" {
+			atomic.AddInt32(&detections, 1)
+		}
+		return jsonResponse(http.StatusOK, `[]`), nil
+	})
+
+	_, err := client.ListZones(context.Background())
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Zero(t, atomic.LoadInt32(&detections))
+}
+
+func newCachingTestClient(fn roundTripFunc) *PowerDNSClient {
+	return &PowerDNSClient{
+		serverID: "localhost",
+		BaseClient: &BaseClient{
+			ServerURL:   "https://pdns.example.test",
+			APIKey:      "test-key",
+			APIVersion:  1,
+			HTTP:        &http.Client{Transport: fn},
+			CacheEnable: true,
+			CacheSize:   1024 * 1024,
+			Cache:       freecache.NewCache(1024 * 1024),
+			CacheTTL:    30,
+		},
+	}
+}
+
+const oneRecordZone = `{"id":"example.com.","name":"example.com.","rrsets":[` +
+	`{"name":"www.example.com.","type":"A","ttl":300,"records":[{"content":"192.0.2.1"}]}]}`
+
+// Writing a record must drop the zone from the cache; otherwise the read that
+// Terraform issues straight after the write is served the pre-write zone and
+// recorded as drift.
+func TestWriteInvalidatesZoneCache(t *testing.T) {
+	var listCalls int32
+
+	client := newCachingTestClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet {
+			atomic.AddInt32(&listCalls, 1)
+			return jsonResponse(http.StatusOK, oneRecordZone), nil
+		}
+		return jsonResponse(http.StatusNoContent, ``), nil
+	})
+
+	ctx := context.Background()
+
+	_, err := client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, int32(1), atomic.LoadInt32(&listCalls)) {
+		return
+	}
+
+	// Second read is served from cache.
+	_, err = client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, int32(1), atomic.LoadInt32(&listCalls), "second read should hit the cache") {
+		return
+	}
+
+	_, err = client.ReplaceRecordSet(ctx, "example.com.", ResourceRecordSet{
+		Name:    "www.example.com.",
+		Type:    "A",
+		TTL:     300,
+		Records: []Record{{Content: "192.0.2.2"}},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// The write invalidated the zone, so this must go back to the server.
+	_, err = client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, int32(2), atomic.LoadInt32(&listCalls),
+		"read after write should refetch instead of serving the stale zone")
+}
+
+func TestDeleteRecordSetInvalidatesZoneCache(t *testing.T) {
+	var listCalls int32
+
+	client := newCachingTestClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet {
+			atomic.AddInt32(&listCalls, 1)
+			return jsonResponse(http.StatusOK, oneRecordZone), nil
+		}
+		return jsonResponse(http.StatusNoContent, ``), nil
+	})
+
+	ctx := context.Background()
+
+	_, err := client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	if !assert.NoError(t, client.DeleteRecordSet(ctx, "example.com.", "www.example.com.", "A")) {
+		return
+	}
+
+	_, err = client.ListRecords(ctx, "example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, int32(2), atomic.LoadInt32(&listCalls))
+}
+
+// Path segments reach the API as user input and must not be able to alter the
+// request path.
+func TestEndpointsEscapePathSegments(t *testing.T) {
+	var gotPath string
+
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		gotPath = r.URL.EscapedPath()
+		return jsonResponse(http.StatusOK, `{"kind":"X","metadata":[]}`), nil
+	})
+
+	_, err := client.GetZoneMetadata(context.Background(), "ex ample.com.", "ALLOW-AXFR-FROM")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.NotContains(t, gotPath, " ")
+	assert.Contains(t, gotPath, "ex%20ample.com.")
+}
+
+// A zone that is absent has no records; that is not an error, but any other
+// failure status must be reported rather than read as an empty zone.
+func TestListRecordsMissingZoneIsEmptyButErrorsSurface(t *testing.T) {
+	missing := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, `{"error":"Not Found"}`), nil
+	})
+	records, err := missing.ListRecords(context.Background(), "gone.example.com.")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Empty(t, records)
+
+	unauthorized := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusUnauthorized, `{"error":"Unauthorized"}`), nil
+	})
+	_, err = unauthorized.ListRecords(context.Background(), "example.com.")
+	if !assert.Error(t, err) {
+		return
+	}
+	assert.True(t, strings.Contains(err.Error(), "Unauthorized"))
+}

--- a/powerdns/resource_powerdns_network.go
+++ b/powerdns/resource_powerdns_network.go
@@ -2,6 +2,7 @@ package powerdns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -64,8 +65,8 @@ func resourcePDNSNetworkUpsert(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	tflog.SetField(ctx, "network", network)
-	tflog.SetField(ctx, "view", view)
+	ctx = tflog.SetField(ctx, "network", network)
+	ctx = tflog.SetField(ctx, "view", view)
 	tflog.Debug(ctx, "Creating or updating PowerDNS network")
 
 	if err := client.PDNS.SetNetwork(ctx, ip, prefixlen, view); err != nil {
@@ -85,12 +86,12 @@ func resourcePDNSNetworkRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	tflog.SetField(ctx, "network", networkCIDR)
+	ctx = tflog.SetField(ctx, "network", networkCIDR)
 	tflog.Debug(ctx, "Reading PowerDNS network")
 
 	network, err := client.PDNS.GetNetwork(ctx, ip, prefixlen)
 	if err != nil {
-		if err == ErrNotFound {
+		if errors.Is(err, ErrNotFound) {
 			d.SetId("")
 			return nil
 		}
@@ -116,10 +117,10 @@ func resourcePDNSNetworkDelete(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	tflog.SetField(ctx, "network", networkCIDR)
+	ctx = tflog.SetField(ctx, "network", networkCIDR)
 	tflog.Debug(ctx, "Deleting PowerDNS network")
 
-	if err := client.PDNS.DeleteNetwork(ctx, ip, prefixlen); err != nil && err != ErrNotFound {
+	if err := client.PDNS.DeleteNetwork(ctx, ip, prefixlen); err != nil && !errors.Is(err, ErrNotFound) {
 		return diag.FromErr(fmt.Errorf("failed to delete network %s: %w", networkCIDR, err))
 	}
 

--- a/powerdns/resource_powerdns_ptr_record.go
+++ b/powerdns/resource_powerdns_ptr_record.go
@@ -64,8 +64,8 @@ func resourcePDNSPTRRecordCreate(ctx context.Context, d *schema.ResourceData, me
 	ttl := d.Get("ttl").(int)
 	reverseZone := d.Get("reverse_zone").(string)
 
-	tflog.SetField(ctx, "ip_address", ipAddress)
-	tflog.SetField(ctx, "reverse_zone", reverseZone)
+	ctx = tflog.SetField(ctx, "ip_address", ipAddress)
+	ctx = tflog.SetField(ctx, "reverse_zone", reverseZone)
 	tflog.Debug(ctx, "Creating PTR record")
 
 	// Get the PTR record name
@@ -114,8 +114,8 @@ func resourcePDNSPTRRecordRead(ctx context.Context, d *schema.ResourceData, meta
 	ipAddress := d.Get("ip_address").(string)
 	reverseZone := d.Get("reverse_zone").(string)
 
-	tflog.SetField(ctx, "ip_address", ipAddress)
-	tflog.SetField(ctx, "reverse_zone", reverseZone)
+	ctx = tflog.SetField(ctx, "ip_address", ipAddress)
+	ctx = tflog.SetField(ctx, "reverse_zone", reverseZone)
 	tflog.Debug(ctx, "Reading PTR record")
 
 	// Get the PTR record name
@@ -170,8 +170,8 @@ func resourcePDNSPTRRecordDelete(ctx context.Context, d *schema.ResourceData, me
 	ipAddress := d.Get("ip_address").(string)
 	reverseZone := d.Get("reverse_zone").(string)
 
-	tflog.SetField(ctx, "ip_address", ipAddress)
-	tflog.SetField(ctx, "reverse_zone", reverseZone)
+	ctx = tflog.SetField(ctx, "ip_address", ipAddress)
+	ctx = tflog.SetField(ctx, "reverse_zone", reverseZone)
 	tflog.Debug(ctx, "Deleting PTR record")
 
 	// Get the PTR record name

--- a/powerdns/resource_powerdns_record.go
+++ b/powerdns/resource_powerdns_record.go
@@ -148,9 +148,9 @@ func resourcePDNSRecordUpsert(ctx context.Context, d *schema.ResourceData, meta 
 	rrSet.Records = records
 	rrSet.Comments = configuredRRSetComments(d)
 
-	tflog.SetField(ctx, "zone", zone)
-	tflog.SetField(ctx, "name", name)
-	tflog.SetField(ctx, "type", typ)
+	ctx = tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "name", name)
+	ctx = tflog.SetField(ctx, "type", typ)
 	tflog.Debug(ctx, "Creating PowerDNS record set")
 
 	recID, err := client.PDNS.ReplaceRecordSet(ctx, zone, rrSet)
@@ -168,8 +168,8 @@ func resourcePDNSRecordRead(ctx context.Context, d *schema.ResourceData, meta in
 	client := meta.(*ProviderClients)
 
 	zone := d.Get("zone").(string)
-	tflog.SetField(ctx, "zone", zone)
-	tflog.SetField(ctx, "record_id", d.Id())
+	ctx = tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "record_id", d.Id())
 	tflog.Debug(ctx, "Reading PowerDNS Record")
 
 	rrSet, err := client.PDNS.GetRecordSetByID(ctx, zone, d.Id())
@@ -221,8 +221,8 @@ func resourcePDNSRecordDelete(ctx context.Context, d *schema.ResourceData, meta 
 	client := meta.(*ProviderClients)
 
 	zone := d.Get("zone").(string)
-	tflog.SetField(ctx, "zone", zone)
-	tflog.SetField(ctx, "record_id", d.Id())
+	ctx = tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "record_id", d.Id())
 	tflog.Debug(ctx, "Deleting PowerDNS Record")
 
 	if err := client.PDNS.DeleteRecordSetByID(ctx, zone, d.Id()); err != nil {

--- a/powerdns/resource_powerdns_record_soa.go
+++ b/powerdns/resource_powerdns_record_soa.go
@@ -157,8 +157,8 @@ func resourcePDNSRecordSOACreateOrUpdate(ctx context.Context, d *schema.Resource
 		},
 	}
 
-	tflog.SetField(ctx, "zone", zone)
-	tflog.SetField(ctx, "name", name)
+	ctx = tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "name", name)
 	tflog.Debug(ctx, "Creating/updating PowerDNS SOA record")
 
 	recID, err := client.PDNS.ReplaceRecordSet(ctx, zone, rrSet)
@@ -176,8 +176,8 @@ func resourcePDNSRecordSOARead(ctx context.Context, d *schema.ResourceData, meta
 	client := meta.(*ProviderClients)
 
 	zone := d.Get("zone").(string)
-	tflog.SetField(ctx, "zone", zone)
-	tflog.SetField(ctx, "record_id", d.Id())
+	ctx = tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "record_id", d.Id())
 	tflog.Debug(ctx, "Reading PowerDNS SOA record")
 
 	records, err := client.PDNS.ListRecordsByID(ctx, zone, d.Id())
@@ -234,8 +234,8 @@ func resourcePDNSRecordSOADelete(ctx context.Context, d *schema.ResourceData, me
 	client := meta.(*ProviderClients)
 
 	zone := d.Get("zone").(string)
-	tflog.SetField(ctx, "zone", zone)
-	tflog.SetField(ctx, "record_id", d.Id())
+	ctx = tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "record_id", d.Id())
 	tflog.Debug(ctx, "Deleting PowerDNS SOA record")
 
 	if err := client.PDNS.DeleteRecordSetByID(ctx, zone, d.Id()); err != nil {

--- a/powerdns/resource_powerdns_recursor_config.go
+++ b/powerdns/resource_powerdns_recursor_config.go
@@ -65,7 +65,7 @@ func resourcePDNSRecursorConfigCreate(ctx context.Context, d *schema.ResourceDat
 		values[i] = v.(string)
 	}
 
-	tflog.SetField(ctx, "recursor_config_name", name)
+	ctx = tflog.SetField(ctx, "recursor_config_name", name)
 	tflog.Debug(ctx, "Creating recursor config")
 
 	if err := recursorClient.SetConfig(ctx, name, values); err != nil {
@@ -84,7 +84,7 @@ func resourcePDNSRecursorConfigRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	name := d.Id()
-	tflog.SetField(ctx, "recursor_config_name", name)
+	ctx = tflog.SetField(ctx, "recursor_config_name", name)
 	tflog.Debug(ctx, "Reading recursor config")
 
 	setting, err := recursorClient.GetConfig(ctx, name)
@@ -122,7 +122,7 @@ func resourcePDNSRecursorConfigUpdate(ctx context.Context, d *schema.ResourceDat
 		values[i] = v.(string)
 	}
 
-	tflog.SetField(ctx, "recursor_config_name", name)
+	ctx = tflog.SetField(ctx, "recursor_config_name", name)
 	tflog.Debug(ctx, "Updating recursor config")
 
 	if err := recursorClient.SetConfig(ctx, name, values); err != nil {
@@ -134,7 +134,7 @@ func resourcePDNSRecursorConfigUpdate(ctx context.Context, d *schema.ResourceDat
 
 func resourcePDNSRecursorConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	name := d.Id()
-	tflog.SetField(ctx, "recursor_config_name", name)
+	ctx = tflog.SetField(ctx, "recursor_config_name", name)
 	tflog.Debug(ctx, "Deleting recursor config")
 
 	// The API only supports GET and PUT for config, so delete will do nothing

--- a/powerdns/resource_powerdns_recursor_forward_zone.go
+++ b/powerdns/resource_powerdns_recursor_forward_zone.go
@@ -59,7 +59,7 @@ func resourcePDNSRecursorForwardZoneCreate(ctx context.Context, d *schema.Resour
 	zoneName := d.Get("zone").(string)
 	rawServers := d.Get("servers").([]interface{})
 
-	tflog.SetField(ctx, "zone", zoneName)
+	ctx = tflog.SetField(ctx, "zone", zoneName)
 	tflog.Debug(ctx, "Creating recursor forward zone")
 
 	servers := make([]string, len(rawServers))
@@ -92,7 +92,7 @@ func resourcePDNSRecursorForwardZoneRead(ctx context.Context, d *schema.Resource
 
 	zoneName := d.Id()
 
-	tflog.SetField(ctx, "zone", zoneName)
+	ctx = tflog.SetField(ctx, "zone", zoneName)
 	tflog.Debug(ctx, "Reading recursor forward zone")
 
 	zone, err := recursorClient.GetForwardZone(ctx, zoneName)
@@ -131,7 +131,7 @@ func resourcePDNSRecursorForwardZoneUpdate(ctx context.Context, d *schema.Resour
 	zoneName := d.Id()
 	rawServers := d.Get("servers").([]interface{})
 
-	tflog.SetField(ctx, "zone", zoneName)
+	ctx = tflog.SetField(ctx, "zone", zoneName)
 	tflog.Debug(ctx, "Updating recursor forward zone")
 
 	servers := make([]string, len(rawServers))
@@ -167,7 +167,7 @@ func resourcePDNSRecursorForwardZoneDelete(ctx context.Context, d *schema.Resour
 
 	zoneName := d.Id()
 
-	tflog.SetField(ctx, "zone", zoneName)
+	ctx = tflog.SetField(ctx, "zone", zoneName)
 	tflog.Debug(ctx, "Deleting recursor forward zone")
 
 	err := recursorClient.DeleteForwardZone(ctx, zoneName)

--- a/powerdns/resource_powerdns_reverse_zone.go
+++ b/powerdns/resource_powerdns_reverse_zone.go
@@ -145,36 +145,20 @@ func resourcePDNSReverseZoneUpdate(ctx context.Context, d *schema.ResourceData, 
 	if d.HasChange("nameservers") {
 		tflog.Debug(ctx, "Updating nameservers for reverse zone")
 
-		zone, err := client.PDNS.GetZone(ctx, zoneName)
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("couldn't fetch zone: %w", err))
-		}
+		// Only the NS records change here. Echoing the zone's unchanged Kind,
+		// Account and SoaEditAPI back through UpdateZone cost a fetch and a
+		// write without altering anything.
+		nameservers := expandStringList(d.Get("nameservers").([]interface{}))
 
-		// Update nameservers in zone object
-		zone.Nameservers = expandStringList(d.Get("nameservers").([]interface{}))
-
-		// Build update request
-		zoneInfo := ZoneInfoUpd{
-			Name:       zoneName,
-			Kind:       zone.Kind,
-			Account:    zone.Account,
-			SoaEditAPI: zone.SoaEditAPI,
-		}
-
-		if err := client.PDNS.UpdateZone(ctx, zoneName, zoneInfo); err != nil {
-			return diag.FromErr(fmt.Errorf("error updating zone: %w", err))
-		}
-
-		// Update NS records to reflect nameserver list
 		rrSet := ResourceRecordSet{
 			Name:       zoneName,
 			Type:       "NS",
 			TTL:        3600,
 			ChangeType: "REPLACE",
-			Records:    make([]Record, len(zone.Nameservers)),
+			Records:    make([]Record, len(nameservers)),
 		}
 
-		for i, ns := range zone.Nameservers {
+		for i, ns := range nameservers {
 			rrSet.Records[i] = Record{
 				Content: ns,
 				TTL:     3600,

--- a/powerdns/resource_powerdns_reverse_zone.go
+++ b/powerdns/resource_powerdns_reverse_zone.go
@@ -66,7 +66,7 @@ func resourcePDNSReverseZoneCreate(ctx context.Context, d *schema.ResourceData, 
 	client := meta.(*ProviderClients)
 
 	cidr := d.Get("cidr").(string)
-	tflog.SetField(ctx, "cidr", cidr)
+	ctx = tflog.SetField(ctx, "cidr", cidr)
 	tflog.Debug(ctx, "Creating reverse zone")
 
 	zoneName, err := GetReverseZoneName(cidr)
@@ -95,7 +95,7 @@ func resourcePDNSReverseZoneRead(ctx context.Context, d *schema.ResourceData, me
 	client := meta.(*ProviderClients)
 	zoneName := d.Id()
 
-	tflog.SetField(ctx, "zone", zoneName)
+	ctx = tflog.SetField(ctx, "zone", zoneName)
 	tflog.Debug(ctx, "Reading reverse zone")
 
 	zone, err := client.PDNS.GetZone(ctx, zoneName)
@@ -141,7 +141,7 @@ func resourcePDNSReverseZoneUpdate(ctx context.Context, d *schema.ResourceData, 
 	client := meta.(*ProviderClients)
 	zoneName := d.Id()
 
-	tflog.SetField(ctx, "zone", zoneName)
+	ctx = tflog.SetField(ctx, "zone", zoneName)
 	if d.HasChange("nameservers") {
 		tflog.Debug(ctx, "Updating nameservers for reverse zone")
 
@@ -195,7 +195,7 @@ func resourcePDNSReverseZoneDelete(ctx context.Context, d *schema.ResourceData, 
 	client := meta.(*ProviderClients)
 	zoneName := d.Id()
 
-	tflog.SetField(ctx, "zone", zoneName)
+	ctx = tflog.SetField(ctx, "zone", zoneName)
 	tflog.Debug(ctx, "Deleting reverse zone")
 
 	if err := client.PDNS.DeleteZone(ctx, zoneName); err != nil {

--- a/powerdns/resource_powerdns_view_zone_association.go
+++ b/powerdns/resource_powerdns_view_zone_association.go
@@ -2,6 +2,7 @@ package powerdns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -52,8 +53,8 @@ func resourcePDNSViewZoneAssociationCreate(ctx context.Context, d *schema.Resour
 	view := d.Get("view").(string)
 	zone := d.Get("zone").(string)
 
-	tflog.SetField(ctx, "view", view)
-	tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "view", view)
+	ctx = tflog.SetField(ctx, "zone", zone)
 	tflog.Debug(ctx, "Creating PowerDNS view zone association")
 
 	if err := client.PDNS.AddZoneToView(ctx, view, zone); err != nil {
@@ -71,13 +72,13 @@ func resourcePDNSViewZoneAssociationRead(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	tflog.SetField(ctx, "view", view)
-	tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "view", view)
+	ctx = tflog.SetField(ctx, "zone", zone)
 	tflog.Debug(ctx, "Reading PowerDNS view zone association")
 
 	pdnsView, err := client.PDNS.GetView(ctx, view)
 	if err != nil {
-		if err == ErrNotFound {
+		if errors.Is(err, ErrNotFound) {
 			d.SetId("")
 			return nil
 		}
@@ -107,11 +108,11 @@ func resourcePDNSViewZoneAssociationDelete(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 
-	tflog.SetField(ctx, "view", view)
-	tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "view", view)
+	ctx = tflog.SetField(ctx, "zone", zone)
 	tflog.Debug(ctx, "Deleting PowerDNS view zone association")
 
-	if err := client.PDNS.RemoveZoneFromView(ctx, view, zone); err != nil && err != ErrNotFound {
+	if err := client.PDNS.RemoveZoneFromView(ctx, view, zone); err != nil && !errors.Is(err, ErrNotFound) {
 		return diag.FromErr(fmt.Errorf("failed to remove zone %s from view %s: %w", zone, view, err))
 	}
 

--- a/powerdns/resource_powerdns_view_zone_association_test.go
+++ b/powerdns/resource_powerdns_view_zone_association_test.go
@@ -2,6 +2,7 @@ package powerdns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"testing"
@@ -96,7 +97,7 @@ func testAccCheckPDNSViewZoneAssociationDestroy(s *terraform.State) error {
 		client := testAccProvider.Meta().(*ProviderClients).PDNS
 		view, err := client.GetView(context.Background(), viewName)
 		if err != nil {
-			if err == ErrNotFound {
+			if errors.Is(err, ErrNotFound) {
 				continue
 			}
 			return fmt.Errorf("error getting view %s: %w", viewName, err)

--- a/powerdns/resource_powerdns_zone.go
+++ b/powerdns/resource_powerdns_zone.go
@@ -111,8 +111,8 @@ func resourcePDNSZoneCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
-	tflog.SetField(ctx, "zone_name", zoneInfo.Name)
-	tflog.SetField(ctx, "zone_kind", zoneInfo.Kind)
+	ctx = tflog.SetField(ctx, "zone_name", zoneInfo.Name)
+	ctx = tflog.SetField(ctx, "zone_kind", zoneInfo.Kind)
 	tflog.Debug(ctx, "Creating PowerDNS Zone")
 
 	createdZoneInfo, err := client.PDNS.CreateZone(ctx, zoneInfo)
@@ -128,7 +128,7 @@ func resourcePDNSZoneCreate(ctx context.Context, d *schema.ResourceData, meta in
 func resourcePDNSZoneRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderClients)
 
-	tflog.SetField(ctx, "zone_id", d.Id())
+	ctx = tflog.SetField(ctx, "zone_id", d.Id())
 	tflog.Debug(ctx, "Reading PowerDNS Zone")
 
 	zoneInfo, err := client.PDNS.GetZone(ctx, d.Id())
@@ -168,7 +168,7 @@ func resourcePDNSZoneRead(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourcePDNSZoneUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	tflog.SetField(ctx, "zone_id", d.Id())
+	ctx = tflog.SetField(ctx, "zone_id", d.Id())
 	tflog.Debug(ctx, "Updating PowerDNS Zone")
 
 	client := meta.(*ProviderClients)
@@ -199,7 +199,7 @@ func resourcePDNSZoneUpdate(ctx context.Context, d *schema.ResourceData, meta in
 func resourcePDNSZoneDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderClients)
 
-	tflog.SetField(ctx, "zone_id", d.Id())
+	ctx = tflog.SetField(ctx, "zone_id", d.Id())
 	tflog.Debug(ctx, "Deleting PowerDNS Zone")
 
 	if err := client.PDNS.DeleteZone(ctx, d.Id()); err != nil {

--- a/powerdns/resource_powerdns_zone_metadata.go
+++ b/powerdns/resource_powerdns_zone_metadata.go
@@ -53,8 +53,8 @@ func resourcePDNSZoneMetadataCreate(ctx context.Context, d *schema.ResourceData,
 	kind := d.Get("kind").(string)
 	values := expandStringSet(d.Get("metadata").(*schema.Set))
 
-	tflog.SetField(ctx, "zone", zone)
-	tflog.SetField(ctx, "kind", kind)
+	ctx = tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "kind", kind)
 	tflog.Debug(ctx, "Creating PowerDNS zone metadata")
 
 	if err := client.PDNS.ReplaceZoneMetadata(ctx, zone, kind, values); err != nil {
@@ -71,8 +71,8 @@ func resourcePDNSZoneMetadataRead(ctx context.Context, d *schema.ResourceData, m
 	zone := d.Get("zone").(string)
 	kind := d.Get("kind").(string)
 
-	tflog.SetField(ctx, "zone", zone)
-	tflog.SetField(ctx, "kind", kind)
+	ctx = tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "kind", kind)
 	tflog.Debug(ctx, "Reading PowerDNS zone metadata")
 
 	allMetadata, err := client.PDNS.ListZoneMetadata(ctx, zone)
@@ -122,8 +122,8 @@ func resourcePDNSZoneMetadataDelete(ctx context.Context, d *schema.ResourceData,
 	zone := d.Get("zone").(string)
 	kind := d.Get("kind").(string)
 
-	tflog.SetField(ctx, "zone", zone)
-	tflog.SetField(ctx, "kind", kind)
+	ctx = tflog.SetField(ctx, "zone", zone)
+	ctx = tflog.SetField(ctx, "kind", kind)
 	tflog.Debug(ctx, "Deleting PowerDNS zone metadata")
 
 	if err := client.PDNS.DeleteZoneMetadata(ctx, zone, kind); err != nil {


### PR DESCRIPTION
Analysis pass over the provider. Several bugs were each duplicated across ~25 near-identical client methods, so the duplication is fixed too.

**Bugs**
- All 55 `tflog.SetField` calls discarded their return value, so every structured log field in the provider was silently dropped.
- `ctx` was accepted everywhere but never attached to any request, so Terraform cancellation didn't abort in-flight calls.
- Cache was written but never invalidated — with `cache_requests = true`, a read after a write in the same apply could be served the pre-write zone and recorded as drift.
- Zone cache keys were the caller's literal spelling. DNS names are case-insensitive, so `example.com.` and `Example.COM.` name one zone but got two entries, and a write under one spelling left a stale entry under the other. Keys are now normalized, preserving PowerDNS zone-variant suffixes (`example.com..internal`) verbatim since those are API identifiers rather than DNS names.
- `APIVersion` detection was an unsynchronized read-modify-write on a client shared across Terraform's parallel graph walk: a real data race plus N redundant probes. Now `sync.Once`.
- Path segments were interpolated raw into URLs at 21 sites; zone names, metadata kinds and view names are user input, and `?`/`#`/`%` corrupted the path.
- `DefaultCacheSize` was a mutable package global written by a constructor, so two clients with different sizes raced. Now per-client, and only allocated when caching is enabled.
- `err == ErrNotFound` → `errors.Is`; two discarded `json.Marshal` errors; `sanitizeURL` discarded its reparse error.

**Refactor**
- `client.go` was 1569 lines, ~70% copy-paste: 26 `HTTP.Do` calls, 27 identical body-close blocks, 27 near-identical error-decode blocks. All calls now route through `BaseClient.do` in the new `request.go` — **1569 → 975 lines**, plus 235 in `request.go`. This is what made the escaping, cache and version fixes single-site rather than 20+ scattered edits.

**Performance**
- `GetRecordSetByID` fetched and decoded every RRset in the zone to find one; now filters server-side via `rrset_name`/`rrset_type`. 52% smaller response on a 5-RRset zone, scaling with zone size.
- Reverse zone updates did a `GetZone` + `UpdateZone` that echoed back unchanged fields before replacing the NS records — two API calls that changed nothing.

**Testing**
Confirmed against the live API before writing the filter code: matching is case-insensitive (matching existing `EqualFold` semantics), comments survive the filter, and unknown query params are ignored rather than rejected — so an older server returns the full zone and the retained client-side match still narrows it down. No version gate needed.

21 unit tests cover the refactor, run without a live server. The new `request.go` sits at 70–100% per function, since every endpoint now depends on it. Beyond that, tests target the paths this branch made riskier:

- **Recursor not-found handling.** The recursor answers an unknown forward zone with a 422, not a 404, so absence is recognised by matching the server's message inside the error `statusError` now builds — a coupling across two files. Covered in both directions: a 422 naming a missing domain becomes `ErrNotFound`, while an unrelated 422 stays an error rather than being misread as "zone absent".
- **`ZoneExists`**, one of the few callers using the new "non-success status as data" contract (`okCodes: {200, 404}`, then inspecting the returned status) — 200, 404 and 500 all checked.
- **Zone-write cache invalidation**, including that a *failed* write leaves the cache intact, which pins the ordering of the error check against the invalidation.

Package coverage 31.5% → 33.0%; `ZoneExists`, `CreateZone`, `UpdateZone` and `GetForwardZone` went from 0% to full. The overall number stays modest because the bulk of the package is Terraform CRUD plumbing reachable only by acceptance tests against a live PowerDNS.
