### PR TITLE
fix: normalize zone cache keys so case variants share one entry

### DIFF
--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -732,10 +732,25 @@ func (client *PowerDNSClient) DeleteZoneMetadata(ctx context.Context, zone strin
 	return nil
 }
 
+// zoneCacheKey is the cache key for a zone. DNS names are case-insensitive, so
+// "example.com." and "Example.COM." name one zone and must share one entry:
+// keying on the caller's spelling would let a write under one spelling leave a
+// stale entry under another. Only the zone part is lowered - a PowerDNS zone
+// variant ("example.com..internal") keeps its variant suffix verbatim, since
+// that is an API identifier rather than a DNS name.
+func zoneCacheKey(zone string) []byte {
+	name, variant, hasVariant := strings.Cut(zone, "..")
+	key := strings.ToLower(name)
+	if hasVariant {
+		key += ".." + variant
+	}
+	return []byte(key)
+}
+
 // GetZoneInfoFromCache return ZoneInfo struct
 func (client *PowerDNSClient) GetZoneInfoFromCache(ctx context.Context, zone string) (*ZoneInfo, error) {
 	if client.CacheEnable {
-		cacheZoneInfo, err := client.Cache.Get([]byte(zone))
+		cacheZoneInfo, err := client.Cache.Get(zoneCacheKey(zone))
 		if err != nil {
 			return nil, err
 		}
@@ -810,7 +825,7 @@ func (client *PowerDNSClient) ListRecords(ctx context.Context, zone string) ([]R
 				return nil, err
 			}
 
-			if err := client.Cache.Set([]byte(zone), cacheValue, client.CacheTTL); err != nil {
+			if err := client.Cache.Set(zoneCacheKey(zone), cacheValue, client.CacheTTL); err != nil {
 				return nil, fmt.Errorf("the cache for REST API requests is enabled but the size isn't enough: cacheSize: %db \n %s",
 					DefaultCacheSize, err)
 			}

--- a/powerdns/client_zone_cache_test.go
+++ b/powerdns/client_zone_cache_test.go
@@ -1,0 +1,65 @@
+package powerdns
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/coocood/freecache"
+	"github.com/stretchr/testify/assert"
+)
+
+const oneRecordZone = `{"name":"example.com.","kind":"Native","rrsets":[{"name":"www.example.com.","type":"A","ttl":300,"records":[{"content":"192.0.2.1","disabled":false}]}]}`
+
+// newCachingTestClient returns a client with the request cache switched on, so
+// a second lookup of the same zone is served from cache instead of the server.
+func newCachingTestClient(fn roundTripFunc) *PowerDNSClient {
+	client := newTestClient(fn)
+	client.CacheEnable = true
+	client.Cache = freecache.NewCache(1024 * 1024)
+	client.CacheTTL = 60
+	return client
+}
+
+// DNS names are case-insensitive, so two config sites naming one zone with
+// different capitalisation must share a cache entry rather than each getting
+// their own. Seeding the cache under one spelling and reading it back under
+// another asserts that directly, without depending on ListRecords' cache-miss
+// path (which on this code treats an ordinary miss as a hard error).
+func TestZoneCacheKeyIsCaseInsensitive(t *testing.T) {
+	var listCalls int32
+
+	client := newCachingTestClient(func(r *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&listCalls, 1)
+		return jsonResponse(http.StatusOK, oneRecordZone), nil
+	})
+
+	ctx := context.Background()
+
+	if !assert.NoError(t, client.Cache.Set(zoneCacheKey("example.com."), []byte(oneRecordZone), client.CacheTTL)) {
+		return
+	}
+
+	zoneInfo, err := client.GetZoneInfoFromCache(ctx, "Example.COM.")
+	if !assert.NoError(t, err, "a case variant should find the cached entry") {
+		return
+	}
+	if assert.NotNil(t, zoneInfo) {
+		assert.Equal(t, "example.com.", zoneInfo.Name)
+	}
+	assert.Equal(t, int32(0), atomic.LoadInt32(&listCalls),
+		"the cached entry should be served without contacting the server")
+}
+
+// Zone variants are distinct zones in PowerDNS: the name is case-insensitive
+// but the variant suffix is an API identifier and must stay verbatim.
+func TestZoneCacheKeyPreservesVariant(t *testing.T) {
+	assert.Equal(t, "example.com.", string(zoneCacheKey("Example.COM.")))
+
+	// The base is lowered, the variant suffix is left exactly as given.
+	assert.Equal(t, "example.com..internal", string(zoneCacheKey("Example.COM..internal")))
+
+	// A variant is a different zone from the plain name and must not collide.
+	assert.NotEqual(t, string(zoneCacheKey("example.com.")), string(zoneCacheKey("example.com..internal")))
+}


### PR DESCRIPTION
### What

DNS names are case-insensitive, so `example.com.` and `Example.COM.` name one zone and must share one cache entry. Keying on the caller's spelling meant a write under one spelling could leave a stale entry under another.

`zoneCacheKey` lowercases the zone name before it is used as a cache key. PowerDNS zone variants (`example.com..internal`) keep their variant suffix verbatim — that suffix is an API identifier, not a DNS name, so it is not case-folded and does not collide with the plain zone.

### Unrelated bug found while testing

`GetZoneInfoFromCache` returns freecache's `Entry not found` as a hard error, and `ListRecords` propagates it — so with caching enabled, the *first* lookup of any zone fails outright instead of falling through to the API. That is a pre-existing bug on `main`, independent of this change, and I have left it alone here.
