### PR TITLE
Refuse to create a record set that already exists instead of replacing it

### DIFF
--- a/powerdns/record_overwrite_guard.go
+++ b/powerdns/record_overwrite_guard.go
@@ -1,0 +1,41 @@
+package powerdns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// errRecordExists explains that a record set is already present on the server.
+// PowerDNS stores one record set per name and type and its API upserts them, so
+// creating one that already exists would replace whatever is there. Refusing is
+// the only way to keep an unmanaged record from being destroyed by an apply.
+func errRecordExists(resourceType, zone, name, recordType string) error {
+	return fmt.Errorf(
+		"a %s record set for %q already exists in zone %s and is not managed by this resource. "+
+			"Creating it would replace the existing record. Import it instead:\n"+
+			"  terraform import %s.<name> '{\"zone\": %q, \"id\": \"%s:::%s\"}'",
+		recordType, name, zone, resourceType, zone, name, recordType)
+}
+
+// guardRecordOverwrite fails when a record set already exists on the server.
+// Callers must only use it on create: an update legitimately rewrites the
+// record set it already owns.
+func guardRecordOverwrite(ctx context.Context, client *PowerDNSClient, resourceType, zone, name, recordType string) error {
+	exists, err := client.RecordExists(ctx, zone, name, recordType)
+	if err != nil {
+		// A missing zone is reported by the zone resource itself, and any other
+		// failure will resurface on the write that follows, so a failed check
+		// must not block the apply on its own.
+		if errors.Is(err, ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("couldn't check whether %s %q already exists in zone %s: %w", recordType, name, zone, err)
+	}
+
+	if exists {
+		return errRecordExists(resourceType, zone, name, recordType)
+	}
+
+	return nil
+}

--- a/powerdns/record_overwrite_guard_test.go
+++ b/powerdns/record_overwrite_guard_test.go
@@ -1,0 +1,83 @@
+package powerdns
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const guardZoneWithRecord = `{"name":"example.com.","kind":"Native","rrsets":[{"name":"www.example.com.","type":"A","ttl":300,"records":[{"content":"192.0.2.1","disabled":false}]}]}`
+
+// Creating over a record set that is already on the server would destroy it,
+// so the guard has to refuse and point at import instead.
+func TestGuardRecordOverwriteBlocksExisting(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, guardZoneWithRecord), nil
+	})
+
+	err := guardRecordOverwrite(context.Background(), client, "powerdns_record", "example.com.", "www.example.com.", "A")
+	if !assert.Error(t, err) {
+		return
+	}
+	assert.Contains(t, err.Error(), "already exists")
+	// The message has to carry a command the user can actually run.
+	assert.Contains(t, err.Error(), "terraform import powerdns_record")
+	assert.Contains(t, err.Error(), `"id": "www.example.com.:::A"`)
+}
+
+func TestGuardRecordOverwriteAllowsNewName(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, guardZoneWithRecord), nil
+	})
+
+	err := guardRecordOverwrite(context.Background(), client, "powerdns_record", "example.com.", "fresh.example.com.", "A")
+	assert.NoError(t, err)
+}
+
+// A different type at the same name is a separate record set in PowerDNS.
+func TestGuardRecordOverwriteAllowsDifferentType(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, guardZoneWithRecord), nil
+	})
+
+	err := guardRecordOverwrite(context.Background(), client, "powerdns_record", "example.com.", "www.example.com.", "TXT")
+	assert.NoError(t, err)
+}
+
+// A missing zone is reported by the zone resource, so the guard must not turn
+// it into a second confusing error on every record in that zone.
+func TestGuardRecordOverwriteIgnoresMissingZone(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, `{"error":"Not Found"}`), nil
+	})
+
+	err := guardRecordOverwrite(context.Background(), client, "powerdns_record", "missing.example.com.", "www.missing.example.com.", "A")
+	assert.NoError(t, err)
+}
+
+// Any other failure has to surface rather than being read as "does not exist",
+// which would let the apply through and overwrite the record after all.
+func TestGuardRecordOverwriteSurfacesOtherErrors(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusInternalServerError, `{"error":"boom"}`), nil
+	})
+
+	err := guardRecordOverwrite(context.Background(), client, "powerdns_record", "example.com.", "www.example.com.", "A")
+	if assert.Error(t, err) {
+		assert.True(t, strings.Contains(err.Error(), "couldn't check"), "got: %v", err)
+	}
+}
+
+// Record names are case-insensitive in DNS, so a differently-cased spelling of
+// an existing record must still be caught.
+func TestGuardRecordOverwriteIsCaseInsensitive(t *testing.T) {
+	client := newTestClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, guardZoneWithRecord), nil
+	})
+
+	err := guardRecordOverwrite(context.Background(), client, "powerdns_record", "example.com.", "WWW.Example.COM.", "a")
+	assert.Error(t, err)
+}

--- a/powerdns/resource_powerdns_ptr_record.go
+++ b/powerdns/resource_powerdns_ptr_record.go
@@ -80,6 +80,10 @@ func resourcePDNSPTRRecordCreate(ctx context.Context, d *schema.ResourceData, me
 		suffix = ".ip6.arpa."
 	}
 
+	if err := guardRecordOverwrite(ctx, client.PDNS, "powerdns_ptr_record", reverseZone, ptrName+suffix, "PTR"); err != nil {
+		return diag.FromErr(err)
+	}
+
 	// Create the PTR record with full FQDN
 	rrSet := ResourceRecordSet{
 		Name:       ptrName + suffix,

--- a/powerdns/resource_powerdns_record.go
+++ b/powerdns/resource_powerdns_record.go
@@ -79,6 +79,16 @@ func resourcePDNSRecord() *schema.Resource {
 }
 
 func resourcePDNSRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*ProviderClients)
+
+	zone := d.Get("zone").(string)
+	name := d.Get("name").(string)
+	typ := d.Get("type").(string)
+
+	if err := guardRecordOverwrite(ctx, client.PDNS, "powerdns_record", zone, name, typ); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return resourcePDNSRecordUpsert(ctx, d, meta)
 }
 

--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -1128,3 +1128,42 @@ resource "powerdns_record" "test-soa" {
 	ttl = 3600
 	records = [ "something.something. hostmaster.sysa.xyz. 2019090301 10800 3600 604800 3600" ]
 }`
+
+// Two resources naming the same record set would otherwise both report success
+// while the server keeps only one of them, leaving a plan that never converges.
+func TestAccPDNSRecordDuplicateRRSetIsRejected(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testPDNSRecordConfigDuplicateRRSet,
+				ExpectError: regexp.MustCompile(`already exists in zone`),
+			},
+		},
+	})
+}
+
+const testPDNSRecordConfigDuplicateRRSet = `
+resource "powerdns_zone" "dup-guard" {
+	name = "dup-guard.sysa.xyz."
+	kind = "Native"
+}
+
+resource "powerdns_record" "dup-a" {
+	zone    = powerdns_zone.dup-guard.name
+	name    = "dup.dup-guard.sysa.xyz."
+	type    = "A"
+	ttl     = 300
+	records = ["192.0.2.1"]
+}
+
+resource "powerdns_record" "dup-b" {
+	zone       = powerdns_zone.dup-guard.name
+	name       = "dup.dup-guard.sysa.xyz."
+	type       = "A"
+	ttl        = 300
+	records    = ["192.0.2.2"]
+	depends_on = [powerdns_record.dup-a]
+}`

--- a/website/docs/r/ptr_record.html.markdown
+++ b/website/docs/r/ptr_record.html.markdown
@@ -73,6 +73,8 @@ resource "powerdns_ptr_record" "example_ipv6" {
 }
 ```
 
+~> **Note:** PowerDNS stores a single record set per name and type, and its API replaces one wholesale. Creating a resource for a record set that already exists on the server is therefore refused, so that an apply cannot destroy a record it does not manage. Import the existing record instead. The same applies to two resources that name the same record set, which would otherwise overwrite each other on every apply.
+
 ## Argument Reference
 
 This resource supports the following arguments:

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -428,6 +428,8 @@ Different DNS record types require specific formatting for their content. Here a
 3. **TXT records not validating**: Ensure proper quoting and escaping of special characters
 4. **SRV records not found**: Verify the service name format (`_service._protocol.domain`)
 
+~> **Note:** PowerDNS stores a single record set per name and type, and its API replaces one wholesale. Creating a resource for a record set that already exists on the server is therefore refused, so that an apply cannot destroy a record it does not manage. Import the existing record instead. The same applies to two resources that name the same record set, which would otherwise overwrite each other on every apply.
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
Creating a record that is already present on the server currently destroys it without any warning. Applying a `powerdns_record` for a name and type that already exists reports `1 added` while the previous value is gone, so a mistyped record name can quietly overwrite live DNS. The same cause makes two resources that name one record set both report success, after which each apply flips the value back and forth and the plan never settles.

PowerDNS stores a single record set per name and type and its API replaces one wholesale, so the provider has to be the one to notice. Creating a record set that already exists is now refused with an error naming the record and giving the exact import command for it. Updates are untouched, since a resource rewriting the record set it already owns is the normal case.

`powerdns_record_soa` is deliberately left alone: every zone is created with an SOA already in place, so managing that existing record is the entire purpose of the resource.

Verified against PowerDNS Authoritative 5.1.4 in Docker. A pre-existing record now survives the apply that used to destroy it, the suggested import command works as printed, and ordinary creates and updates still behave as before.

Please note this is a behaviour change: a configuration that relies on creating over an existing record will now fail until the record is imported. That seemed clearly preferable to losing DNS records silently, but it is your call whether it should wait for a major release.

Dependency note: this touches `powerdns/resource_powerdns_record.go` and `powerdns/resource_powerdns_ptr_record.go`, which #104 also modifies. The changes are in different functions, so no conflict is expected, but whichever merges second may need a trivial rebase. It shares no files with #99, #100, #101, #102, #103, #105, #106 or #107.